### PR TITLE
Feat/7 ocr

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,10 +40,10 @@ jobs:
       - name: Check import order with isort
         run: uv run isort --check-only src tests
 
-      - name: Install system dependencies for PyQt6
+      - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libegl1 libxcb-cursor0 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 xvfb  
+          sudo apt-get install -y libegl1 libxcb-cursor0 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 xvfb tesseract-ocr tesseract-ocr-eng
 
       - name: Run tests with pytest
         run: xvfb-run uv run pytest tests --cov=src --cov-report=term --cov-report=xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,11 @@ dependencies = [
     "black>=26.3.1",
     "flake8>=7.3.0",
     "isort>=5.13.0",
+    "Pillow>=11.0.0",
     "pyqt6>=6.11.0",
+    "pytesseract>=0.3.10",
     "pytest>=9.0.3",
     "pytest-cov>=4.1.0",
-
 ]
 
 [project.scripts]
@@ -20,11 +21,9 @@ app = "src.main:main"
 requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools]
-packages = ["src"]
-
-[tool.setuptools.package-dir]
-"" = "."
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["src", "src.*"]
 
 [tool.black]
 line-length = 120

--- a/src/ai/__init__.py
+++ b/src/ai/__init__.py
@@ -1,0 +1,13 @@
+"""AI module for RedactAI -- ML models for detecting sensitive information."""
+
+from src.ai.ocr import extract_text, run_ocr
+from src.ai.types import BoundingBox, OCRResult, OCRWord, TextDetection
+
+__all__ = [
+    "BoundingBox",
+    "OCRResult",
+    "OCRWord",
+    "TextDetection",
+    "extract_text",
+    "run_ocr",
+]

--- a/src/ai/__init__.py
+++ b/src/ai/__init__.py
@@ -1,6 +1,6 @@
 """AI module for RedactAI -- ML models for detecting sensitive information."""
 
-from src.ai.ocr import extract_text, run_ocr
+from src.ai.ocr import ocr
 from src.ai.types import BoundingBox, OCRResult, OCRWord, TextDetection
 
 __all__ = [
@@ -8,6 +8,5 @@ __all__ = [
     "OCRResult",
     "OCRWord",
     "TextDetection",
-    "extract_text",
-    "run_ocr",
+    "ocr",
 ]

--- a/src/ai/ocr.py
+++ b/src/ai/ocr.py
@@ -28,7 +28,7 @@ from PIL import Image
 from src.ai.types import BoundingBox, OCRResult, OCRWord, TextDetection
 
 
-def run_ocr(images: list[Image.Image], lang: str = "eng") -> OCRResult:
+def ocr(images: list[Image.Image], lang: str = "eng") -> list[OCRResult]:
     """Run Tesseract OCR on a list of images.
 
     Args:
@@ -36,7 +36,7 @@ def run_ocr(images: list[Image.Image], lang: str = "eng") -> OCRResult:
         lang: Tesseract language code (default ``"eng"``).
 
     Returns:
-        An ``OCRResult`` containing one ``TextDetection`` per input image.
+        A list of ``OCRResult`` objects, one per input image.
 
     Raises:
         TypeError: If any element in *images* is not a ``PIL.Image.Image``.
@@ -46,11 +46,10 @@ def run_ocr(images: list[Image.Image], lang: str = "eng") -> OCRResult:
         if not isinstance(img, Image.Image):
             raise TypeError(f"Expected PIL.Image.Image, got {type(img).__name__}")
 
-    detections = [_process_single_image(img, lang) for img in images]
-    return OCRResult(detections=detections)
+    return [OCRResult(detections=[_process_single_image(img, lang)]) for img in images]
 
 
-def extract_text(images: list[Image.Image], lang: str = "eng") -> list[str]:
+def _extract_text(images: list[Image.Image], lang: str = "eng") -> list[str]:
     """Convenience wrapper that returns only the assembled text strings.
 
     Args:
@@ -60,8 +59,8 @@ def extract_text(images: list[Image.Image], lang: str = "eng") -> list[str]:
     Returns:
         A list of strings, one per input image.
     """
-    result = run_ocr(images, lang=lang)
-    return [d.text for d in result.detections]
+    results = ocr(images, lang=lang)
+    return [d.text for r in results for d in r.detections]
 
 
 def _process_single_image(image: Image.Image, lang: str) -> TextDetection:

--- a/src/ai/ocr.py
+++ b/src/ai/ocr.py
@@ -1,0 +1,140 @@
+"""Tesseract OCR integration for RedactAI.
+
+Extracts word-level text and bounding boxes from images using pytesseract.
+Requires the Tesseract binary to be installed on the system
+(e.g. ``brew install tesseract`` on macOS, ``apt-get install tesseract-ocr`` on Ubuntu).
+
+## OCR string format contract (for T3.2 NLP and T2.1 Pipeline)
+
+The full text string returned in ``TextDetection.text`` is assembled as follows:
+
+  - Words on the **same line**: joined by a single space ``" "``
+  - **Lines** within the same block: joined by ``"\\n"``
+  - Separate **blocks**: joined by ``"\\n\\n"``
+
+Every ``OCRWord`` records its ``char_offset`` — the exact start index of that word
+in the assembled string. This allows the pipeline to map NLP character indices
+back to pixel-level bounding boxes.
+"""
+
+from __future__ import annotations
+
+from itertools import groupby
+from operator import itemgetter
+
+import pytesseract
+from PIL import Image
+
+from src.ai.types import BoundingBox, OCRResult, OCRWord, TextDetection
+
+
+def run_ocr(images: list[Image.Image], lang: str = "eng") -> OCRResult:
+    """Run Tesseract OCR on a list of images.
+
+    Args:
+        images: PIL Image objects to process.
+        lang: Tesseract language code (default ``"eng"``).
+
+    Returns:
+        An ``OCRResult`` containing one ``TextDetection`` per input image.
+
+    Raises:
+        TypeError: If any element in *images* is not a ``PIL.Image.Image``.
+        pytesseract.TesseractNotFoundError: If the Tesseract binary is not installed.
+    """
+    for img in images:
+        if not isinstance(img, Image.Image):
+            raise TypeError(f"Expected PIL.Image.Image, got {type(img).__name__}")
+
+    detections = [_process_single_image(img, lang) for img in images]
+    return OCRResult(detections=detections)
+
+
+def extract_text(images: list[Image.Image], lang: str = "eng") -> list[str]:
+    """Convenience wrapper that returns only the assembled text strings.
+
+    Args:
+        images: PIL Image objects to process.
+        lang: Tesseract language code (default ``"eng"``).
+
+    Returns:
+        A list of strings, one per input image.
+    """
+    result = run_ocr(images, lang=lang)
+    return [d.text for d in result.detections]
+
+
+def _process_single_image(image: Image.Image, lang: str) -> TextDetection:
+    """Extract text and word-level bounding boxes from a single image."""
+    data = pytesseract.image_to_data(image, lang=lang, output_type=pytesseract.Output.DICT)
+
+    n_entries = len(data["text"])
+
+    rows = []
+    for i in range(n_entries):
+        text = data["text"][i].strip()
+        conf = float(data["conf"][i])
+        if not text or conf == -1:
+            continue
+        rows.append(
+            {
+                "block_num": data["block_num"][i],
+                "par_num": data["par_num"][i],
+                "line_num": data["line_num"][i],
+                "word_num": data["word_num"][i],
+                "left": data["left"][i],
+                "top": data["top"][i],
+                "width": data["width"][i],
+                "height": data["height"][i],
+                "conf": conf,
+                "text": text,
+            }
+        )
+
+    if not rows:
+        return TextDetection(text="", words=[])
+
+    rows.sort(key=lambda r: (r["block_num"], r["par_num"], r["line_num"], r["word_num"]))
+
+    text_parts: list[str] = []
+    words: list[OCRWord] = []
+    char_pos = 0
+
+    block_line_key = itemgetter("block_num", "par_num", "line_num")
+
+    prev_block: int | None = None
+    prev_line_key: tuple | None = None
+
+    for line_key, line_words_iter in groupby(rows, key=block_line_key):
+        line_words = list(line_words_iter)
+        current_block = line_words[0]["block_num"]
+
+        if prev_line_key is not None:
+            if current_block != prev_block:
+                separator = "\n\n"
+            else:
+                separator = "\n"
+            text_parts.append(separator)
+            char_pos += len(separator)
+
+        for j, w in enumerate(line_words):
+            if j > 0:
+                text_parts.append(" ")
+                char_pos += 1
+
+            text_parts.append(w["text"])
+            words.append(
+                OCRWord(
+                    text=w["text"],
+                    bounding_box=BoundingBox(x=w["left"], y=w["top"], width=w["width"], height=w["height"]),
+                    confidence=w["conf"],
+                    char_offset=char_pos,
+                )
+            )
+            char_pos += len(w["text"])
+
+        prev_block = current_block
+        prev_line_key = line_key
+
+    full_text = "".join(text_parts)
+    return TextDetection(text=full_text, words=words)

--- a/src/ai/types.py
+++ b/src/ai/types.py
@@ -1,0 +1,67 @@
+"""Shared data types for the AI module.
+
+These types define the interface contract between:
+  - T3.1 OCR  (produces TextDetection with full text + word-level bounding boxes)
+  - T3.2 NLP  (consumes the plain text string, produces NLPEntity with char indices)
+  - T2.1 Pipeline (maps NLP char indices back to pixel bounding boxes via OCRWord.char_offset)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class BoundingBox:
+    """Axis-aligned bounding box in pixel coordinates."""
+
+    x: int
+    y: int
+    width: int
+    height: int
+
+
+@dataclass(frozen=True)
+class OCRWord:
+    """A single word detected by OCR, with its position in both pixel and text space.
+
+    Attributes:
+        text: The word string as reported by Tesseract.
+        bounding_box: Pixel-level location in the source image.
+        confidence: Tesseract confidence score (0-100).
+        char_offset: Start index of this word in the parent TextDetection.text string.
+            Invariant: ``detection.text[word.char_offset:word.char_offset + len(word.text)] == word.text``
+    """
+
+    text: str
+    bounding_box: BoundingBox
+    confidence: float
+    char_offset: int
+
+
+@dataclass(frozen=True)
+class TextDetection:
+    """OCR result for a single image.
+
+    ``text`` is the full reassembled string built from Tesseract's word-level output
+    using the following join contract:
+
+      - Words on the same line: joined by ``" "`` (single space)
+      - Lines in the same block: joined by ``"\\n"``
+      - Separate blocks: joined by ``"\\n\\n"``
+
+    This is the exact string that the NLP module (T3.2) receives. Character indices
+    produced by NLP (``NLPEntity.start`` / ``NLPEntity.end``) refer to positions in
+    this string. The pipeline (T2.1) maps those indices back to pixel rectangles by
+    scanning ``words`` and matching on ``OCRWord.char_offset``.
+    """
+
+    text: str
+    words: list[OCRWord]
+
+
+@dataclass(frozen=True)
+class OCRResult:
+    """Top-level return type from ``run_ocr``. One ``TextDetection`` per input image."""
+
+    detections: list[TextDetection]

--- a/src/ai/types.py
+++ b/src/ai/types.py
@@ -62,6 +62,6 @@ class TextDetection:
 
 @dataclass(frozen=True)
 class OCRResult:
-    """Top-level return type from ``run_ocr``. One ``TextDetection`` per input image."""
+    """OCR result for a single image. Contains all ``TextDetection`` objects found in that image."""
 
     detections: list[TextDetection]

--- a/tests/ai/conftest.py
+++ b/tests/ai/conftest.py
@@ -1,0 +1,42 @@
+"""Shared fixtures for AI module tests."""
+
+from __future__ import annotations
+
+import shutil
+
+import pytest
+from PIL import Image, ImageDraw, ImageFont
+
+pytesseract_available = pytest.mark.skipif(
+    shutil.which("tesseract") is None,
+    reason="Tesseract OCR not installed",
+)
+
+
+def _get_large_font(size: int = 36) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
+    """Return a font large enough for reliable OCR."""
+    try:
+        return ImageFont.load_default(size=size)
+    except TypeError:
+        return ImageFont.load_default()
+
+
+@pytest.fixture
+def sample_ocr_image() -> Image.Image:
+    """A 400x100 white image with 'Hello World' in large black text."""
+    img = Image.new("RGB", (400, 100), color="white")
+    draw = ImageDraw.Draw(img)
+    font = _get_large_font(36)
+    draw.text((10, 30), "Hello World", fill="black", font=font)
+    return img
+
+
+@pytest.fixture
+def multiline_ocr_image() -> Image.Image:
+    """A 400x200 white image with two lines of text on separate lines."""
+    img = Image.new("RGB", (400, 200), color="white")
+    draw = ImageDraw.Draw(img)
+    font = _get_large_font(36)
+    draw.text((10, 20), "First Line", fill="black", font=font)
+    draw.text((10, 110), "Second Line", fill="black", font=font)
+    return img

--- a/tests/ai/conftest.py
+++ b/tests/ai/conftest.py
@@ -2,15 +2,8 @@
 
 from __future__ import annotations
 
-import shutil
-
 import pytest
 from PIL import Image, ImageDraw, ImageFont
-
-pytesseract_available = pytest.mark.skipif(
-    shutil.which("tesseract") is None,
-    reason="Tesseract OCR not installed",
-)
 
 
 def _get_large_font(size: int = 36) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:

--- a/tests/ai/test_ocr.py
+++ b/tests/ai/test_ocr.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import pytest
 from PIL import Image
 
-from src.ai.ocr import extract_text, run_ocr
+from src.ai.ocr import ocr
 from src.ai.types import BoundingBox, OCRResult, TextDetection
 from tests.ai.conftest import pytesseract_available
 
@@ -206,66 +206,69 @@ WITH_EMPTY_TEXT = _make_tesseract_dict(
 # ---------------------------------------------------------------------------
 
 
-class TestRunOcrReturnType:
+class TestOcrReturnType:
     @patch("src.ai.ocr.pytesseract.image_to_data", return_value=TWO_WORDS_SAME_LINE)
-    def test_returns_ocr_result(self, mock_data):
+    def test_returns_list_of_ocr_results(self, mock_data):
         img = Image.new("RGB", (100, 50))
-        result = run_ocr([img])
-        assert isinstance(result, OCRResult)
-        assert len(result.detections) == 1
-        assert isinstance(result.detections[0], TextDetection)
+        result = ocr([img])
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert isinstance(result[0], OCRResult)
+        assert len(result[0].detections) == 1
+        assert isinstance(result[0].detections[0], TextDetection)
 
     @patch("src.ai.ocr.pytesseract.image_to_data", return_value=TWO_WORDS_SAME_LINE)
     def test_multiple_images(self, mock_data):
         imgs = [Image.new("RGB", (100, 50)), Image.new("RGB", (100, 50))]
-        result = run_ocr(imgs)
-        assert len(result.detections) == 2
+        result = ocr(imgs)
+        assert len(result) == 2
+        assert all(isinstance(r, OCRResult) for r in result)
 
 
 class TestTextAssembly:
     @patch("src.ai.ocr.pytesseract.image_to_data", return_value=TWO_WORDS_SAME_LINE)
     def test_space_between_words_on_same_line(self, mock_data):
-        result = run_ocr([Image.new("RGB", (100, 50))])
-        assert result.detections[0].text == "Hello World"
+        result = ocr([Image.new("RGB", (100, 50))])
+        assert result[0].detections[0].text == "Hello World"
 
     @patch("src.ai.ocr.pytesseract.image_to_data", return_value=TWO_LINES_SAME_BLOCK)
     def test_newline_between_lines(self, mock_data):
-        result = run_ocr([Image.new("RGB", (100, 50))])
-        assert result.detections[0].text == "Line1\nLine2"
+        result = ocr([Image.new("RGB", (100, 50))])
+        assert result[0].detections[0].text == "Line1\nLine2"
 
     @patch("src.ai.ocr.pytesseract.image_to_data", return_value=TWO_BLOCKS)
     def test_double_newline_between_blocks(self, mock_data):
-        result = run_ocr([Image.new("RGB", (100, 50))])
-        assert result.detections[0].text == "BlockA\n\nBlockB"
+        result = ocr([Image.new("RGB", (100, 50))])
+        assert result[0].detections[0].text == "BlockA\n\nBlockB"
 
 
 class TestCharOffsets:
     @patch("src.ai.ocr.pytesseract.image_to_data", return_value=TWO_WORDS_SAME_LINE)
     def test_offsets_on_same_line(self, mock_data):
-        result = run_ocr([Image.new("RGB", (100, 50))])
-        words = result.detections[0].words
+        result = ocr([Image.new("RGB", (100, 50))])
+        words = result[0].detections[0].words
         assert words[0].char_offset == 0  # "Hello" starts at 0
         assert words[1].char_offset == 6  # "World" starts at 6 (after "Hello ")
 
     @patch("src.ai.ocr.pytesseract.image_to_data", return_value=TWO_LINES_SAME_BLOCK)
     def test_offsets_across_lines(self, mock_data):
-        result = run_ocr([Image.new("RGB", (100, 50))])
-        words = result.detections[0].words
+        result = ocr([Image.new("RGB", (100, 50))])
+        words = result[0].detections[0].words
         assert words[0].char_offset == 0  # "Line1"
         assert words[1].char_offset == 6  # "Line2" (after "Line1\n")
 
     @patch("src.ai.ocr.pytesseract.image_to_data", return_value=TWO_BLOCKS)
     def test_offsets_across_blocks(self, mock_data):
-        result = run_ocr([Image.new("RGB", (100, 50))])
-        words = result.detections[0].words
+        result = ocr([Image.new("RGB", (100, 50))])
+        words = result[0].detections[0].words
         assert words[0].char_offset == 0  # "BlockA"
         assert words[1].char_offset == 8  # "BlockB" (after "BlockA\n\n")
 
     @patch("src.ai.ocr.pytesseract.image_to_data", return_value=TWO_WORDS_SAME_LINE)
     def test_char_offset_invariant(self, mock_data):
         """The fundamental contract: text[offset:offset+len] == word.text."""
-        result = run_ocr([Image.new("RGB", (100, 50))])
-        det = result.detections[0]
+        result = ocr([Image.new("RGB", (100, 50))])
+        det = result[0].detections[0]
         for word in det.words:
             assert det.text[word.char_offset : word.char_offset + len(word.text)] == word.text
 
@@ -273,45 +276,45 @@ class TestCharOffsets:
 class TestBoundingBoxes:
     @patch("src.ai.ocr.pytesseract.image_to_data", return_value=TWO_WORDS_SAME_LINE)
     def test_bounding_box_values_preserved(self, mock_data):
-        result = run_ocr([Image.new("RGB", (100, 50))])
-        box = result.detections[0].words[0].bounding_box
+        result = ocr([Image.new("RGB", (100, 50))])
+        box = result[0].detections[0].words[0].bounding_box
         assert box == BoundingBox(x=10, y=20, width=50, height=15)
 
 
 class TestFiltering:
     @patch("src.ai.ocr.pytesseract.image_to_data", return_value=WITH_LOW_CONF)
     def test_filters_negative_confidence(self, mock_data):
-        result = run_ocr([Image.new("RGB", (100, 50))])
-        words = result.detections[0].words
+        result = ocr([Image.new("RGB", (100, 50))])
+        words = result[0].detections[0].words
         assert len(words) == 1
         assert words[0].text == "real"
 
     @patch("src.ai.ocr.pytesseract.image_to_data", return_value=WITH_EMPTY_TEXT)
     def test_filters_empty_and_whitespace_text(self, mock_data):
-        result = run_ocr([Image.new("RGB", (100, 50))])
-        words = result.detections[0].words
+        result = ocr([Image.new("RGB", (100, 50))])
+        words = result[0].detections[0].words
         assert len(words) == 1
         assert words[0].text == "visible"
 
     @patch("src.ai.ocr.pytesseract.image_to_data", return_value=EMPTY_DICT)
     def test_empty_image_returns_empty_detection(self, mock_data):
-        result = run_ocr([Image.new("RGB", (100, 50))])
-        det = result.detections[0]
+        result = ocr([Image.new("RGB", (100, 50))])
+        det = result[0].detections[0]
         assert det.text == ""
         assert det.words == []
 
 
-class TestExtractText:
+class TestOcrTextContent:
     @patch("src.ai.ocr.pytesseract.image_to_data", return_value=TWO_WORDS_SAME_LINE)
-    def test_returns_list_of_strings(self, mock_data):
-        result = extract_text([Image.new("RGB", (100, 50))])
-        assert result == ["Hello World"]
+    def test_detection_contains_expected_text(self, mock_data):
+        result = ocr([Image.new("RGB", (100, 50))])
+        assert result[0].detections[0].text == "Hello World"
 
 
 class TestInputValidation:
     def test_non_image_raises_type_error(self):
         with pytest.raises(TypeError, match="Expected PIL.Image.Image"):
-            run_ocr(["not_an_image"])
+            ocr(["not_an_image"])
 
 
 # ---------------------------------------------------------------------------
@@ -323,8 +326,8 @@ class TestInputValidation:
 @pytest.mark.integration
 class TestOCRIntegration:
     def test_ocr_on_generated_image(self, sample_ocr_image):
-        result = run_ocr([sample_ocr_image])
-        det = result.detections[0]
+        result = ocr([sample_ocr_image])
+        det = result[0].detections[0]
         text_lower = det.text.lower()
         assert "hello" in text_lower
         assert "world" in text_lower
@@ -334,14 +337,14 @@ class TestOCRIntegration:
             assert word.bounding_box.height > 0
 
     def test_multiline_ocr(self, multiline_ocr_image):
-        result = run_ocr([multiline_ocr_image])
-        det = result.detections[0]
+        result = ocr([multiline_ocr_image])
+        det = result[0].detections[0]
         assert "\n" in det.text
 
     def test_char_offset_contract(self, sample_ocr_image):
         """Every word's char_offset must correctly index into the full text."""
-        result = run_ocr([sample_ocr_image])
-        det = result.detections[0]
+        result = ocr([sample_ocr_image])
+        det = result[0].detections[0]
         for word in det.words:
             actual = det.text[word.char_offset : word.char_offset + len(word.text)]
             assert actual == word.text, (

--- a/tests/ai/test_ocr.py
+++ b/tests/ai/test_ocr.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shutil
 from unittest.mock import patch
 
 import pytest
@@ -9,7 +10,11 @@ from PIL import Image
 
 from src.ai.ocr import ocr
 from src.ai.types import BoundingBox, OCRResult, TextDetection
-from tests.ai.conftest import pytesseract_available
+
+pytesseract_available = pytest.mark.skipif(
+    shutil.which("tesseract") is None,
+    reason="Tesseract OCR not installed",
+)
 
 
 def _make_tesseract_dict(rows: list[dict]) -> dict:

--- a/tests/ai/test_ocr.py
+++ b/tests/ai/test_ocr.py
@@ -1,0 +1,350 @@
+"""Tests for the OCR module."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from PIL import Image
+
+from src.ai.ocr import extract_text, run_ocr
+from src.ai.types import BoundingBox, OCRResult, TextDetection
+from tests.ai.conftest import pytesseract_available
+
+
+def _make_tesseract_dict(rows: list[dict]) -> dict:
+    """Build a pytesseract-style output dict from a compact list of row dicts.
+
+    Each row should have keys: block_num, par_num, line_num, word_num,
+    left, top, width, height, conf, text.
+    """
+    keys = [
+        "level",
+        "page_num",
+        "block_num",
+        "par_num",
+        "line_num",
+        "word_num",
+        "left",
+        "top",
+        "width",
+        "height",
+        "conf",
+        "text",
+    ]
+    result: dict[str, list] = {k: [] for k in keys}
+    for row in rows:
+        result["level"].append(5)
+        result["page_num"].append(1)
+        for k in keys[2:]:
+            result[k].append(row[k])
+    return result
+
+
+EMPTY_DICT = _make_tesseract_dict([])
+
+TWO_WORDS_SAME_LINE = _make_tesseract_dict(
+    [
+        {
+            "block_num": 1,
+            "par_num": 1,
+            "line_num": 1,
+            "word_num": 1,
+            "left": 10,
+            "top": 20,
+            "width": 50,
+            "height": 15,
+            "conf": 95.0,
+            "text": "Hello",
+        },
+        {
+            "block_num": 1,
+            "par_num": 1,
+            "line_num": 1,
+            "word_num": 2,
+            "left": 70,
+            "top": 20,
+            "width": 60,
+            "height": 15,
+            "conf": 92.0,
+            "text": "World",
+        },
+    ]
+)
+
+TWO_LINES_SAME_BLOCK = _make_tesseract_dict(
+    [
+        {
+            "block_num": 1,
+            "par_num": 1,
+            "line_num": 1,
+            "word_num": 1,
+            "left": 10,
+            "top": 10,
+            "width": 40,
+            "height": 15,
+            "conf": 90.0,
+            "text": "Line1",
+        },
+        {
+            "block_num": 1,
+            "par_num": 1,
+            "line_num": 2,
+            "word_num": 1,
+            "left": 10,
+            "top": 40,
+            "width": 40,
+            "height": 15,
+            "conf": 88.0,
+            "text": "Line2",
+        },
+    ]
+)
+
+TWO_BLOCKS = _make_tesseract_dict(
+    [
+        {
+            "block_num": 1,
+            "par_num": 1,
+            "line_num": 1,
+            "word_num": 1,
+            "left": 10,
+            "top": 10,
+            "width": 50,
+            "height": 15,
+            "conf": 93.0,
+            "text": "BlockA",
+        },
+        {
+            "block_num": 2,
+            "par_num": 1,
+            "line_num": 1,
+            "word_num": 1,
+            "left": 10,
+            "top": 100,
+            "width": 50,
+            "height": 15,
+            "conf": 91.0,
+            "text": "BlockB",
+        },
+    ]
+)
+
+WITH_LOW_CONF = _make_tesseract_dict(
+    [
+        {
+            "block_num": 1,
+            "par_num": 1,
+            "line_num": 1,
+            "word_num": 1,
+            "left": 10,
+            "top": 10,
+            "width": 50,
+            "height": 15,
+            "conf": -1,
+            "text": "ghost",
+        },
+        {
+            "block_num": 1,
+            "par_num": 1,
+            "line_num": 1,
+            "word_num": 2,
+            "left": 70,
+            "top": 10,
+            "width": 50,
+            "height": 15,
+            "conf": 90.0,
+            "text": "real",
+        },
+    ]
+)
+
+WITH_EMPTY_TEXT = _make_tesseract_dict(
+    [
+        {
+            "block_num": 1,
+            "par_num": 1,
+            "line_num": 1,
+            "word_num": 1,
+            "left": 10,
+            "top": 10,
+            "width": 50,
+            "height": 15,
+            "conf": 90.0,
+            "text": "",
+        },
+        {
+            "block_num": 1,
+            "par_num": 1,
+            "line_num": 1,
+            "word_num": 2,
+            "left": 70,
+            "top": 10,
+            "width": 50,
+            "height": 15,
+            "conf": 90.0,
+            "text": "   ",
+        },
+        {
+            "block_num": 1,
+            "par_num": 1,
+            "line_num": 1,
+            "word_num": 3,
+            "left": 130,
+            "top": 10,
+            "width": 50,
+            "height": 15,
+            "conf": 90.0,
+            "text": "visible",
+        },
+    ]
+)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests (mocked, no Tesseract binary needed)
+# ---------------------------------------------------------------------------
+
+
+class TestRunOcrReturnType:
+    @patch("src.ai.ocr.pytesseract.image_to_data", return_value=TWO_WORDS_SAME_LINE)
+    def test_returns_ocr_result(self, mock_data):
+        img = Image.new("RGB", (100, 50))
+        result = run_ocr([img])
+        assert isinstance(result, OCRResult)
+        assert len(result.detections) == 1
+        assert isinstance(result.detections[0], TextDetection)
+
+    @patch("src.ai.ocr.pytesseract.image_to_data", return_value=TWO_WORDS_SAME_LINE)
+    def test_multiple_images(self, mock_data):
+        imgs = [Image.new("RGB", (100, 50)), Image.new("RGB", (100, 50))]
+        result = run_ocr(imgs)
+        assert len(result.detections) == 2
+
+
+class TestTextAssembly:
+    @patch("src.ai.ocr.pytesseract.image_to_data", return_value=TWO_WORDS_SAME_LINE)
+    def test_space_between_words_on_same_line(self, mock_data):
+        result = run_ocr([Image.new("RGB", (100, 50))])
+        assert result.detections[0].text == "Hello World"
+
+    @patch("src.ai.ocr.pytesseract.image_to_data", return_value=TWO_LINES_SAME_BLOCK)
+    def test_newline_between_lines(self, mock_data):
+        result = run_ocr([Image.new("RGB", (100, 50))])
+        assert result.detections[0].text == "Line1\nLine2"
+
+    @patch("src.ai.ocr.pytesseract.image_to_data", return_value=TWO_BLOCKS)
+    def test_double_newline_between_blocks(self, mock_data):
+        result = run_ocr([Image.new("RGB", (100, 50))])
+        assert result.detections[0].text == "BlockA\n\nBlockB"
+
+
+class TestCharOffsets:
+    @patch("src.ai.ocr.pytesseract.image_to_data", return_value=TWO_WORDS_SAME_LINE)
+    def test_offsets_on_same_line(self, mock_data):
+        result = run_ocr([Image.new("RGB", (100, 50))])
+        words = result.detections[0].words
+        assert words[0].char_offset == 0  # "Hello" starts at 0
+        assert words[1].char_offset == 6  # "World" starts at 6 (after "Hello ")
+
+    @patch("src.ai.ocr.pytesseract.image_to_data", return_value=TWO_LINES_SAME_BLOCK)
+    def test_offsets_across_lines(self, mock_data):
+        result = run_ocr([Image.new("RGB", (100, 50))])
+        words = result.detections[0].words
+        assert words[0].char_offset == 0  # "Line1"
+        assert words[1].char_offset == 6  # "Line2" (after "Line1\n")
+
+    @patch("src.ai.ocr.pytesseract.image_to_data", return_value=TWO_BLOCKS)
+    def test_offsets_across_blocks(self, mock_data):
+        result = run_ocr([Image.new("RGB", (100, 50))])
+        words = result.detections[0].words
+        assert words[0].char_offset == 0  # "BlockA"
+        assert words[1].char_offset == 8  # "BlockB" (after "BlockA\n\n")
+
+    @patch("src.ai.ocr.pytesseract.image_to_data", return_value=TWO_WORDS_SAME_LINE)
+    def test_char_offset_invariant(self, mock_data):
+        """The fundamental contract: text[offset:offset+len] == word.text."""
+        result = run_ocr([Image.new("RGB", (100, 50))])
+        det = result.detections[0]
+        for word in det.words:
+            assert det.text[word.char_offset : word.char_offset + len(word.text)] == word.text
+
+
+class TestBoundingBoxes:
+    @patch("src.ai.ocr.pytesseract.image_to_data", return_value=TWO_WORDS_SAME_LINE)
+    def test_bounding_box_values_preserved(self, mock_data):
+        result = run_ocr([Image.new("RGB", (100, 50))])
+        box = result.detections[0].words[0].bounding_box
+        assert box == BoundingBox(x=10, y=20, width=50, height=15)
+
+
+class TestFiltering:
+    @patch("src.ai.ocr.pytesseract.image_to_data", return_value=WITH_LOW_CONF)
+    def test_filters_negative_confidence(self, mock_data):
+        result = run_ocr([Image.new("RGB", (100, 50))])
+        words = result.detections[0].words
+        assert len(words) == 1
+        assert words[0].text == "real"
+
+    @patch("src.ai.ocr.pytesseract.image_to_data", return_value=WITH_EMPTY_TEXT)
+    def test_filters_empty_and_whitespace_text(self, mock_data):
+        result = run_ocr([Image.new("RGB", (100, 50))])
+        words = result.detections[0].words
+        assert len(words) == 1
+        assert words[0].text == "visible"
+
+    @patch("src.ai.ocr.pytesseract.image_to_data", return_value=EMPTY_DICT)
+    def test_empty_image_returns_empty_detection(self, mock_data):
+        result = run_ocr([Image.new("RGB", (100, 50))])
+        det = result.detections[0]
+        assert det.text == ""
+        assert det.words == []
+
+
+class TestExtractText:
+    @patch("src.ai.ocr.pytesseract.image_to_data", return_value=TWO_WORDS_SAME_LINE)
+    def test_returns_list_of_strings(self, mock_data):
+        result = extract_text([Image.new("RGB", (100, 50))])
+        assert result == ["Hello World"]
+
+
+class TestInputValidation:
+    def test_non_image_raises_type_error(self):
+        with pytest.raises(TypeError, match="Expected PIL.Image.Image"):
+            run_ocr(["not_an_image"])
+
+
+# ---------------------------------------------------------------------------
+# Integration tests (require Tesseract binary)
+# ---------------------------------------------------------------------------
+
+
+@pytesseract_available
+@pytest.mark.integration
+class TestOCRIntegration:
+    def test_ocr_on_generated_image(self, sample_ocr_image):
+        result = run_ocr([sample_ocr_image])
+        det = result.detections[0]
+        text_lower = det.text.lower()
+        assert "hello" in text_lower
+        assert "world" in text_lower
+        assert len(det.words) >= 2
+        for word in det.words:
+            assert word.bounding_box.width > 0
+            assert word.bounding_box.height > 0
+
+    def test_multiline_ocr(self, multiline_ocr_image):
+        result = run_ocr([multiline_ocr_image])
+        det = result.detections[0]
+        assert "\n" in det.text
+
+    def test_char_offset_contract(self, sample_ocr_image):
+        """Every word's char_offset must correctly index into the full text."""
+        result = run_ocr([sample_ocr_image])
+        det = result.detections[0]
+        for word in det.words:
+            actual = det.text[word.char_offset : word.char_offset + len(word.text)]
+            assert actual == word.text, (
+                f"Contract violation: text[{word.char_offset}:{word.char_offset + len(word.text)}] "
+                f"== {actual!r}, expected {word.text!r}"
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -153,6 +153,39 @@ wheels = [
 ]
 
 [[package]]
+name = "pillow"
+version = "12.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/98/4595daa2365416a86cb0d495248a393dfc84e96d62ad080c8546256cb9c0/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:3adc9215e8be0448ed6e814966ecf3d9952f0ea40eb14e89a102b87f450660d8", size = 4100848, upload-time = "2026-04-01T14:44:48.48Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/79/40184d464cf89f6663e18dfcf7ca21aae2491fff1a16127681bf1fa9b8cf/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:6a9adfc6d24b10f89588096364cc726174118c62130c817c2837c60cf08a392b", size = 4176515, upload-time = "2026-04-01T14:44:51.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/63/703f86fd4c422a9cf722833670f4f71418fb116b2853ff7da722ea43f184/pillow-12.2.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:6a6e67ea2e6feda684ed370f9a1c52e7a243631c025ba42149a2cc5934dec295", size = 3640159, upload-time = "2026-04-01T14:44:53.588Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/fb22f797187d0be2270f83500aab851536101b254bfa1eae10795709d283/pillow-12.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2bb4a8d594eacdfc59d9e5ad972aa8afdd48d584ffd5f13a937a664c3e7db0ed", size = 5312185, upload-time = "2026-04-01T14:44:56.039Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/1a9e46228571de18f8e28f16fabdfc20212a5d019f3e3303452b3f0a580d/pillow-12.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:80b2da48193b2f33ed0c32c38140f9d3186583ce7d516526d462645fd98660ae", size = 4695386, upload-time = "2026-04-01T14:44:58.663Z" },
+    { url = "https://files.pythonhosted.org/packages/70/62/98f6b7f0c88b9addd0e87c217ded307b36be024d4ff8869a812b241d1345/pillow-12.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22db17c68434de69d8ecfc2fe821569195c0c373b25cccb9cbdacf2c6e53c601", size = 6280384, upload-time = "2026-04-01T14:45:01.5Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/03/688747d2e91cfbe0e64f316cd2e8005698f76ada3130d0194664174fa5de/pillow-12.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b14cc0106cd9aecda615dd6903840a058b4700fcb817687d0ee4fc8b6e389be", size = 8091599, upload-time = "2026-04-01T14:45:04.5Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/35/577e22b936fcdd66537329b33af0b4ccfefaeabd8aec04b266528cddb33c/pillow-12.2.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cbeb542b2ebc6fcdacabf8aca8c1a97c9b3ad3927d46b8723f9d4f033288a0f", size = 6396021, upload-time = "2026-04-01T14:45:07.117Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8d/d2532ad2a603ca2b93ad9f5135732124e57811d0168155852f37fbce2458/pillow-12.2.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4bfd07bc812fbd20395212969e41931001fd59eb55a60658b0e5710872e95286", size = 7083360, upload-time = "2026-04-01T14:45:09.763Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/26/d325f9f56c7e039034897e7380e9cc202b1e368bfd04d4cbe6a441f02885/pillow-12.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9aba9a17b623ef750a4d11b742cbafffeb48a869821252b30ee21b5e91392c50", size = 6507628, upload-time = "2026-04-01T14:45:12.378Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f7/769d5632ffb0988f1c5e7660b3e731e30f7f8ec4318e94d0a5d674eb65a4/pillow-12.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:deede7c263feb25dba4e82ea23058a235dcc2fe1f6021025dc71f2b618e26104", size = 7209321, upload-time = "2026-04-01T14:45:15.122Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7a/c253e3c645cd47f1aceea6a8bacdba9991bf45bb7dfe927f7c893e89c93c/pillow-12.2.0-cp314-cp314-win32.whl", hash = "sha256:632ff19b2778e43162304d50da0181ce24ac5bb8180122cbe1bf4673428328c7", size = 6479723, upload-time = "2026-04-01T14:45:17.797Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8b/601e6566b957ca50e28725cb6c355c59c2c8609751efbecd980db44e0349/pillow-12.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:4e6c62e9d237e9b65fac06857d511e90d8461a32adcc1b9065ea0c0fa3a28150", size = 7217400, upload-time = "2026-04-01T14:45:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/94/220e46c73065c3e2951bb91c11a1fb636c8c9ad427ac3ce7d7f3359b9b2f/pillow-12.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:b1c1fbd8a5a1af3412a0810d060a78b5136ec0836c8a4ef9aa11807f2a22f4e1", size = 2554835, upload-time = "2026-04-01T14:45:23.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ab/1b426a3974cb0e7da5c29ccff4807871d48110933a57207b5a676cccc155/pillow-12.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:57850958fe9c751670e49b2cecf6294acc99e562531f4bd317fa5ddee2068463", size = 5314225, upload-time = "2026-04-01T14:45:25.637Z" },
+    { url = "https://files.pythonhosted.org/packages/19/1e/dce46f371be2438eecfee2a1960ee2a243bbe5e961890146d2dee1ff0f12/pillow-12.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d5d38f1411c0ed9f97bcb49b7bd59b6b7c314e0e27420e34d99d844b9ce3b6f3", size = 4698541, upload-time = "2026-04-01T14:45:28.355Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c3/7fbecf70adb3a0c33b77a300dc52e424dc22ad8cdc06557a2e49523b703d/pillow-12.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c0a9f29ca8e79f09de89293f82fc9b0270bb4af1d58bc98f540cc4aedf03166", size = 6322251, upload-time = "2026-04-01T14:45:30.924Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/7fbc17cfb7e4fe0ef1642e0abc17fc6c94c9f7a16be41498e12e2ba60408/pillow-12.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1610dd6c61621ae1cf811bef44d77e149ce3f7b95afe66a4512f8c59f25d9ebe", size = 8127807, upload-time = "2026-04-01T14:45:33.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c3/a8ae14d6defd2e448493ff512fae903b1e9bd40b72efb6ec55ce0048c8ce/pillow-12.2.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a34329707af4f73cf1782a36cd2289c0368880654a2c11f027bcee9052d35dd", size = 6433935, upload-time = "2026-04-01T14:45:36.623Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/32/2880fb3a074847ac159d8f902cb43278a61e85f681661e7419e6596803ed/pillow-12.2.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e9c4f5b3c546fa3458a29ab22646c1c6c787ea8f5ef51300e5a60300736905e", size = 7116720, upload-time = "2026-04-01T14:45:39.258Z" },
+    { url = "https://files.pythonhosted.org/packages/46/87/495cc9c30e0129501643f24d320076f4cc54f718341df18cc70ec94c44e1/pillow-12.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fb043ee2f06b41473269765c2feae53fc2e2fbf96e5e22ca94fb5ad677856f06", size = 6540498, upload-time = "2026-04-01T14:45:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/18/53/773f5edca692009d883a72211b60fdaf8871cbef075eaa9d577f0a2f989e/pillow-12.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f278f034eb75b4e8a13a54a876cc4a5ab39173d2cdd93a638e1b467fc545ac43", size = 7239413, upload-time = "2026-04-01T14:45:44.705Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e4/4b64a97d71b2a83158134abbb2f5bd3f8a2ea691361282f010998f339ec7/pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354", size = 6482084, upload-time = "2026-04-01T14:45:47.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/13/306d275efd3a3453f72114b7431c877d10b1154014c1ebbedd067770d629/pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1", size = 7225152, upload-time = "2026-04-01T14:45:50.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/6e/cf826fae916b8658848d7b9f38d88da6396895c676e8086fc0988073aaf8/pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb", size = 2556579, upload-time = "2026-04-01T14:45:52.529Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.9.6"
 source = { registry = "https://pypi.org/simple" }
@@ -241,6 +274,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytesseract"
+version = "0.3.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a6/7d679b83c285974a7cb94d739b461fa7e7a9b17a3abfd7bf6cbc5c2394b0/pytesseract-0.3.13.tar.gz", hash = "sha256:4bf5f880c99406f52a3cfc2633e42d9dc67615e69d8a509d74867d3baddb5db9", size = 17689, upload-time = "2024-08-16T02:33:56.762Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/33/8312d7ce74670c9d39a532b2c246a853861120486be9443eebf048043637/pytesseract-0.3.13-py3-none-any.whl", hash = "sha256:7a99c6c2ac598360693d83a416e36e0b33a67638bb9d77fdcac094a3589d4b34", size = 14705, upload-time = "2024-08-16T02:36:10.09Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -297,7 +343,9 @@ dependencies = [
     { name = "black" },
     { name = "flake8" },
     { name = "isort" },
+    { name = "pillow" },
     { name = "pyqt6" },
+    { name = "pytesseract" },
     { name = "pytest" },
     { name = "pytest-cov" },
 ]
@@ -307,7 +355,9 @@ requires-dist = [
     { name = "black", specifier = ">=26.3.1" },
     { name = "flake8", specifier = ">=7.3.0" },
     { name = "isort", specifier = ">=5.13.0" },
+    { name = "pillow", specifier = ">=11.0.0" },
     { name = "pyqt6", specifier = ">=6.11.0" },
+    { name = "pytesseract", specifier = ">=0.3.10" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
 ]


### PR DESCRIPTION
Summary

  - Add Tesseract OCR integration via pytesseract that extracts word-level text and bounding-box coordinates from PIL images
  - Introduce shared data types (BoundingBox, OCRWord, TextDetection, OCRResult) under src/ai/ designed for downstream NLP and pipeline consumption
  - Add 15 mocked unit tests and 3 integration tests covering text assembly, char offsets, bounding boxes, filtering, and input validation

  Test plan

  - All 18 tests pass locally (uv run pytest tests/ai/ -v)
  - Formatting and linting clean (black, isort, flake8)
  - CI installs tesseract-ocr + tesseract-ocr-eng so integration tests run in the workflow

  Closes #7