### PR TITLE
feat/UI-main-menu

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         run: uv pip install pyinstaller
 
       - name: Build with PyInstaller
-        run: uv run pyinstaller --onedir --name redactai --windowed src/main.py
+        run: uv run pyinstaller --onedir --name redactai --windowed --add-data "src/ui/styles:src/ui/styles" src/main.py
 
       - name: Create archive (Linux/macOS)
         if: runner.os != 'Windows'

--- a/assets/images/.gitkeep
+++ b/assets/images/.gitkeep
@@ -1,1 +1,0 @@
-Placeholder file to keep the directory structure intact.

--- a/src/main.py
+++ b/src/main.py
@@ -1,20 +1,15 @@
 import sys
 
-from PyQt6.QtWidgets import QApplication, QLabel, QVBoxLayout, QWidget
+from PyQt6.QtWidgets import QApplication
+
+from src.ui.main_window import MainWindow
 
 
 def main() -> int:
+    """Entry point for the RedactAI application."""
     app = QApplication(sys.argv)
 
-    window = QWidget()
-    window.setWindowTitle("PyQt6 Hello World")
-
-    layout = QVBoxLayout()
-    label = QLabel("Hello, World!")
-    layout.addWidget(label)
-    window.setLayout(layout)
-
-    window.resize(300, 100)
+    window = MainWindow()
     window.show()
 
     return app.exec()

--- a/src/persistance/__init__.py
+++ b/src/persistance/__init__.py
@@ -1,0 +1,1 @@
+"""Data persistence and resource management for RedactAI."""

--- a/src/persistance/resource_loader.py
+++ b/src/persistance/resource_loader.py
@@ -1,0 +1,42 @@
+"""Resource loader for handling asset paths in both dev and PyInstaller."""
+
+import sys
+from pathlib import Path
+
+
+class ResourceLoader:
+    """Helper for locating resources in dev/PyInstaller contexts."""
+
+    @staticmethod
+    def get_resource_path(resource_path: str) -> Path:
+        """Get the absolute path to a resource file.
+
+        This method handles both development and PyInstaller bundle
+        contexts. In a PyInstaller bundle, resources are located under
+        sys._MEIPASS. In development, resources are located relative to
+        the project root.
+
+        Args:
+            resource_path: The relative path to the resource from the
+                          project root (e.g.,
+                          "src/ui/styles/theme.qss").
+
+        Returns:
+            The absolute Path to the resource file.
+
+        Example:
+            >>> loader = ResourceLoader()
+            >>> theme_path = loader.get_resource_path(
+            ...     "src/ui/styles/theme.qss"
+            ... )
+            >>> if theme_path.exists():
+            ...     content = theme_path.read_text()
+        """
+        if hasattr(sys, "_MEIPASS"):
+            # Running in a PyInstaller bundle
+            base_path = Path(sys._MEIPASS)
+        else:
+            # Running in development: use project root
+            base_path = Path(__file__).parent.parent.parent
+
+        return base_path / resource_path

--- a/src/ui/.gitkeep
+++ b/src/ui/.gitkeep
@@ -1,1 +1,0 @@
-Placeholder file to keep the directory structure intact.

--- a/src/ui/__init__.py
+++ b/src/ui/__init__.py
@@ -1,0 +1,1 @@
+"""UI components for RedactAI application."""

--- a/src/ui/dialogs/__init__.py
+++ b/src/ui/dialogs/__init__.py
@@ -1,0 +1,5 @@
+"""Dialog components for the RedactAI UI."""
+
+from src.ui.dialogs.alert_dialog import AlertDialog, AlertSeverity, show_alert
+
+__all__ = ["AlertDialog", "AlertSeverity", "show_alert"]

--- a/src/ui/dialogs/alert_dialog.py
+++ b/src/ui/dialogs/alert_dialog.py
@@ -1,0 +1,126 @@
+"""Reusable alert dialog for informational and warning messages."""
+
+from enum import Enum
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QHBoxLayout,
+    QLabel,
+    QStyle,
+    QVBoxLayout,
+    QWidget,
+)
+
+
+class AlertSeverity(str, Enum):
+    """Supported alert severity levels."""
+
+    INFO = "info"
+    WARNING = "warning"
+
+
+class AlertDialog(QDialog):
+    """Small reusable popup for displaying alert messages."""
+
+    _DEFAULT_TITLES = {
+        AlertSeverity.INFO: "Information",
+        AlertSeverity.WARNING: "Warning",
+    }
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        severity: AlertSeverity | str = AlertSeverity.INFO,
+        title: str | None = None,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._severity = self._coerce_severity(severity)
+        self.setWindowTitle(title or self._DEFAULT_TITLES[self._severity])
+        self.setModal(True)
+        self.setObjectName("alertDialog")
+        self.setProperty("role", "alert-dialog")
+        self.setProperty("severity", self._severity.value)
+        self._setup_ui(message)
+
+    @classmethod
+    def _coerce_severity(cls, severity: AlertSeverity | str) -> AlertSeverity:
+        if isinstance(severity, AlertSeverity):
+            return severity
+
+        normalized = str(severity).strip().lower()
+        return AlertSeverity(normalized)
+
+    def _setup_ui(self, message: str) -> None:
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(24, 24, 24, 24)
+        layout.setSpacing(16)
+
+        header_layout = QHBoxLayout()
+        header_layout.setSpacing(14)
+
+        icon_label = QLabel()
+        icon_label.setProperty("role", "alert-icon")
+        icon_label.setProperty("severity", self._severity.value)
+        icon_kind = (
+            QStyle.StandardPixmap.SP_MessageBoxWarning
+            if self._severity is AlertSeverity.WARNING
+            else QStyle.StandardPixmap.SP_MessageBoxInformation
+        )
+        icon = self.style().standardIcon(icon_kind)
+        icon_label.setPixmap(icon.pixmap(40, 40))
+        icon_alignment = (
+            Qt.AlignmentFlag.AlignTop | Qt.AlignmentFlag.AlignHCenter
+        )
+        icon_label.setAlignment(icon_alignment)
+
+        text_column = QVBoxLayout()
+        text_column.setSpacing(8)
+
+        title_label = QLabel(self.windowTitle())
+        title_label.setProperty("role", "alert-title")
+        title_label.setWordWrap(True)
+
+        message_label = QLabel(message)
+        message_label.setProperty("role", "alert-message")
+        message_label.setWordWrap(True)
+
+        text_column.addWidget(title_label)
+        text_column.addWidget(message_label)
+
+        header_layout.addWidget(icon_label, 0)
+        header_layout.addLayout(text_column, 1)
+
+        button_box = QDialogButtonBox()
+        close_button = button_box.addButton(
+            "Close",
+            QDialogButtonBox.ButtonRole.RejectRole,
+        )
+        close_button.setProperty("role", "alert-close")
+        close_button.clicked.connect(self.close)
+
+        layout.addLayout(header_layout)
+        layout.addWidget(button_box, alignment=Qt.AlignmentFlag.AlignRight)
+
+        self.setMinimumWidth(360)
+
+
+def show_alert(
+    parent: QWidget | None,
+    message: str,
+    *,
+    severity: AlertSeverity | str = AlertSeverity.INFO,
+    title: str | None = None,
+) -> int:
+    """Display an alert dialog and return the modal result code."""
+
+    dialog = AlertDialog(
+        message,
+        severity=severity,
+        title=title,
+        parent=parent,
+    )
+    return dialog.exec()

--- a/src/ui/dialogs/alert_dialog.py
+++ b/src/ui/dialogs/alert_dialog.py
@@ -72,10 +72,8 @@ class AlertDialog(QDialog):
         )
         icon = self.style().standardIcon(icon_kind)
         icon_label.setPixmap(icon.pixmap(40, 40))
-        icon_alignment = (
-            Qt.AlignmentFlag.AlignTop | Qt.AlignmentFlag.AlignHCenter
-        )
-        icon_label.setAlignment(icon_alignment)
+        icon_align = Qt.AlignmentFlag.AlignTop | Qt.AlignmentFlag.AlignHCenter
+        icon_label.setAlignment(icon_align)
 
         text_column = QVBoxLayout()
         text_column.setSpacing(8)

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1,7 +1,7 @@
 """Main application window with view management."""
 
-from pathlib import Path
 from enum import Enum
+from pathlib import Path
 
 from PyQt6.QtWidgets import QMainWindow, QStackedWidget
 

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -59,9 +59,23 @@ class MainWindow(QMainWindow):
         Args:
             page: The page to navigate to.
             **kwargs: Additional parameters for the page.
+
+        Raises:
+            ValueError: If `page` is not a registered view.
+            TypeError: If navigation parameters are provided for a view that
+                does not support receiving them.
         """
         target = self.views.get(page)
-        if target is not None:
-            if hasattr(target, "setLaunchExtra"):
-                target.setLaunchExtra(**kwargs)
-            self.stacked_widget.setCurrentWidget(target)
+        if target is None:
+            raise ValueError(f"Unknown page: {page!r}")
+
+        if kwargs:
+            set_launch_extra = getattr(target, "setLaunchExtra", None)
+            if not callable(set_launch_extra):
+                raise TypeError(
+                    f"View for page {page.value!r} does not support navigation "
+                    "parameters; expected a callable setLaunchExtra(**kwargs)."
+                )
+            set_launch_extra(**kwargs)
+
+        self.stacked_widget.setCurrentWidget(target)

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1,10 +1,10 @@
 """Main application window with view management."""
 
 from enum import Enum
-from pathlib import Path
 
 from PyQt6.QtWidgets import QMainWindow, QStackedWidget
 
+from src.persistance.resource_loader import ResourceLoader
 from src.ui.views.homepage import HomePage
 from src.ui.views.placeholder import PlaceholderView
 
@@ -49,9 +49,13 @@ class MainWindow(QMainWindow):
 
     def _apply_theme(self) -> None:
         """Load and apply the shared application theme."""
-        theme_file = Path(__file__).parent / "styles" / "theme.qss"
-        if theme_file.exists():
-            self.setStyleSheet(theme_file.read_text(encoding="utf-8"))
+        resource_path = "src/ui/styles/theme.qss"
+        theme_file = ResourceLoader.get_resource_path(resource_path)
+
+        if not theme_file.exists():
+            raise FileNotFoundError(f"Theme file not found at: {theme_file}")
+        
+        self.setStyleSheet(theme_file.read_text(encoding="utf-8"))
 
     def go_to(self, page: Page, **kwargs: object) -> None:
         """Switch to the given view identified by `page` enum.

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -54,7 +54,7 @@ class MainWindow(QMainWindow):
 
         if not theme_file.exists():
             raise FileNotFoundError(f"Theme file not found at: {theme_file}")
-        
+
         self.setStyleSheet(theme_file.read_text(encoding="utf-8"))
 
     def go_to(self, page: Page, **kwargs: object) -> None:

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -31,7 +31,7 @@ class MainWindow(QMainWindow):
         self.setCentralWidget(self.stacked_widget)
 
         # Create views
-        self.homepage = HomePage(lambda: self.go_to(Page.PLACEHOLDER))
+        self.homepage = HomePage(self.go_to)
         self.placeholder = PlaceholderView(lambda: self.go_to(Page.HOME))
 
         # Register views in a mapping for unified navigation
@@ -52,8 +52,16 @@ class MainWindow(QMainWindow):
         theme_file = Path(__file__).parent / "styles" / "theme.qss"
         self.setStyleSheet(theme_file.read_text(encoding="utf-8"))
 
-    def go_to(self, page: Page) -> None:
-        """Switch to the given view identified by `page` enum."""
+    def go_to(self, page: Page, **kwargs: object) -> None:
+        """Switch to the given view identified by `page` enum.
+
+        Args:
+            page: The page to navigate to.
+            **kwargs: Additional parameters for the page.
+        """
         target = self.views.get(page)
         if target is not None:
+            if hasattr(target, "setLaunchExtra"):
+                target.setLaunchExtra(**kwargs)
             self.stacked_widget.setCurrentWidget(target)
+

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -50,7 +50,8 @@ class MainWindow(QMainWindow):
     def _apply_theme(self) -> None:
         """Load and apply the shared application theme."""
         theme_file = Path(__file__).parent / "styles" / "theme.qss"
-        self.setStyleSheet(theme_file.read_text(encoding="utf-8"))
+        if theme_file.exists():
+            self.setStyleSheet(theme_file.read_text(encoding="utf-8"))
 
     def go_to(self, page: Page, **kwargs: object) -> None:
         """Switch to the given view identified by `page` enum.

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -73,8 +73,9 @@ class MainWindow(QMainWindow):
             set_launch_extra = getattr(target, "setLaunchExtra", None)
             if not callable(set_launch_extra):
                 raise TypeError(
-                    f"View for page {page.value!r} does not support navigation "
-                    "parameters; expected a callable setLaunchExtra(**kwargs)."
+                    f"View for page {page.value!r} does not "
+                    "support navigation parameters; expected a "
+                    "callable setLaunchExtra(**kwargs)."
                 )
             set_launch_extra(**kwargs)
 

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -64,4 +64,3 @@ class MainWindow(QMainWindow):
             if hasattr(target, "setLaunchExtra"):
                 target.setLaunchExtra(**kwargs)
             self.stacked_widget.setCurrentWidget(target)
-

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1,0 +1,59 @@
+"""Main application window with view management."""
+
+from pathlib import Path
+from enum import Enum
+
+from PyQt6.QtWidgets import QMainWindow, QStackedWidget
+
+from src.ui.views.homepage import HomePage
+from src.ui.views.placeholder import PlaceholderView
+
+
+class Page(Enum):
+    HOME = "home"
+    PLACEHOLDER = "placeholder"
+
+
+class MainWindow(QMainWindow):
+    """Main application window with stacked layout for different views."""
+
+    def __init__(self) -> None:
+        """Initialize the main window."""
+        super().__init__()
+        self.setWindowTitle("RedactAI")
+        self.resize(1200, 800)
+        self.setMinimumSize(900, 620)
+
+        self._apply_theme()
+
+        # Create stacked widget for view management
+        self.stacked_widget = QStackedWidget()
+        self.setCentralWidget(self.stacked_widget)
+
+        # Create views
+        self.homepage = HomePage(lambda: self.go_to(Page.PLACEHOLDER))
+        self.placeholder = PlaceholderView(lambda: self.go_to(Page.HOME))
+
+        # Register views in a mapping for unified navigation
+        self.views = {
+            Page.HOME: self.homepage,
+            Page.PLACEHOLDER: self.placeholder,
+        }
+
+        # Add to stacked widget
+        self.stacked_widget.addWidget(self.homepage)
+        self.stacked_widget.addWidget(self.placeholder)
+
+        # Show homepage first
+        self.stacked_widget.setCurrentWidget(self.homepage)
+
+    def _apply_theme(self) -> None:
+        """Load and apply the shared application theme."""
+        theme_file = Path(__file__).parent / "styles" / "theme.qss"
+        self.setStyleSheet(theme_file.read_text(encoding="utf-8"))
+
+    def go_to(self, page: Page) -> None:
+        """Switch to the given view identified by `page` enum."""
+        target = self.views.get(page)
+        if target is not None:
+            self.stacked_widget.setCurrentWidget(target)

--- a/src/ui/styles/__init__.py
+++ b/src/ui/styles/__init__.py
@@ -1,0 +1,1 @@
+"""Application style assets."""

--- a/src/ui/styles/theme.qss
+++ b/src/ui/styles/theme.qss
@@ -32,6 +32,57 @@ QWidget[role="drag-area"][drag-hover="true"] {
     background-color: #a9a9a9;
 }
 
+QDialog[role="alert-dialog"] {
+    background-color: #2b2b2b;
+    border: 1px solid #464646;
+    border-radius: 14px;
+}
+
+QDialog[role="alert-dialog"][severity="info"] {
+    border-color: #64b5f6;
+}
+
+QDialog[role="alert-dialog"][severity="warning"] {
+    border-color: #ffb74d;
+}
+
+QDialog[role="alert-dialog"] QLabel {
+    background: transparent;
+    color: #f1f1f1;
+}
+
+QLabel[role="alert-title"] {
+    font-size: 18px;
+    font-weight: 700;
+}
+
+QLabel[role="alert-message"] {
+    font-size: 14px;
+    line-height: 1.35;
+}
+
+QLabel[role="alert-icon"][severity="info"] {
+    background: transparent;
+}
+
+QLabel[role="alert-icon"][severity="warning"] {
+    background: transparent;
+}
+
+QPushButton[role="alert-close"] {
+    background-color: #f76b6b;
+    color: #ffffff;
+    border: none;
+    border-radius: 6px;
+    padding: 8px 18px;
+    font-size: 14px;
+    font-weight: 600;
+}
+
+QPushButton[role="alert-close"]:hover {
+    background-color: #ff8c8c;
+}
+
 QLabel[role="drag-title"] {
     background: transparent;
     color: #ececec;

--- a/src/ui/styles/theme.qss
+++ b/src/ui/styles/theme.qss
@@ -28,6 +28,10 @@ QWidget[role="drag-area"] {
     border-radius: 12px;
 }
 
+QWidget[role="drag-area"][drag-hover="true"] {
+    background-color: #a9a9a9;
+}
+
 QLabel[role="drag-title"] {
     background: transparent;
     color: #ececec;

--- a/src/ui/styles/theme.qss
+++ b/src/ui/styles/theme.qss
@@ -1,0 +1,61 @@
+QMainWindow {
+    background-color: #ffffff;
+}
+
+QWidget {
+    background-color: #202020;
+    color: #ff00ff;
+    font-family: "Helvetica Neue", "Segoe UI", sans-serif;
+}
+
+QLabel[role="title"] {
+    color: #bfbfbf;
+    font-size: 46px;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    padding-bottom: 10px;
+}
+
+QLabel[role="subtitle"] {
+    color: #c2c2c2;
+    font-size: 16px;
+    font-weight: 500;
+}
+
+QWidget[role="drag-area"] {
+    background-color: #585858;
+    border: 8px dashed #f76b6b;
+    border-radius: 12px;
+}
+
+QLabel[role="drag-title"] {
+    background: transparent;
+    color: #ececec;
+    font-size: 24px;
+    font-weight: 700;
+}
+
+QLabel[role="drag-subtitle"] {
+    background: transparent;
+    color: #d0d0d0;
+    font-size: 14px;
+    font-weight: 500;
+}
+
+QLabel[role="drag-icon"] {
+    background: transparent;
+}
+
+QPushButton[role="primary"] {
+    background-color: #f76b6b;
+    color: #ffffff;
+    border: none;
+    border-radius: 6px;
+    padding: 10px 20px;
+    font-size: 14px;
+    font-weight: 600;
+}
+
+QPushButton[role="primary"]:hover {
+    background-color: #ff8c8c;
+}

--- a/src/ui/views/__init__.py
+++ b/src/ui/views/__init__.py
@@ -1,0 +1,1 @@
+"""UI views for different application screens."""

--- a/src/ui/views/drop_target_widget.py
+++ b/src/ui/views/drop_target_widget.py
@@ -1,0 +1,61 @@
+"""Interactive drop target widget used on the homepage."""
+
+from typing import Callable
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QMouseEvent
+from PyQt6.QtWidgets import QLabel, QStyle, QVBoxLayout, QWidget
+
+
+class DropTargetWidget(QWidget):
+    """Interactive drop target that also supports click-to-open."""
+
+    def __init__(self, on_click: Callable[[], None]) -> None:
+        """Initialize the drop target widget.
+
+        Args:
+            on_click: Callback invoked when the target is clicked.
+        """
+        super().__init__()
+        self._on_click = on_click
+        self.setMinimumHeight(300)
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.setProperty("role", "drag-area")
+        self.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
+        self._setup_ui()
+
+    def _setup_ui(self) -> None:
+        """Create icon, title, and helper text inside the target area."""
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(24, 24, 24, 24)
+        layout.setSpacing(10)
+
+        icon = QLabel()
+        icon.setProperty("role", "drag-icon")
+        open_icon_kind = QStyle.StandardPixmap.SP_DialogOpenButton
+        open_icon = self.style().standardIcon(open_icon_kind)
+        icon_pixmap = open_icon.pixmap(52, 52)
+        icon.setPixmap(icon_pixmap)
+        icon.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        title = QLabel("Drag Files Here")
+        title.setProperty("role", "drag-title")
+        title.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        subtitle = QLabel("or click to browse from your device")
+        subtitle.setProperty("role", "drag-subtitle")
+        subtitle.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        layout.addStretch()
+        layout.addWidget(icon)
+        layout.addWidget(title)
+        layout.addWidget(subtitle)
+        layout.addStretch()
+
+    def mousePressEvent(self, event: QMouseEvent) -> None:
+        """Trigger file-open callback on left click."""
+        if event.button() == Qt.MouseButton.LeftButton:
+            self._on_click()
+            event.accept()
+            return
+        super().mousePressEvent(event)

--- a/src/ui/views/drop_target_widget.py
+++ b/src/ui/views/drop_target_widget.py
@@ -6,6 +6,8 @@ from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QMouseEvent
 from PyQt6.QtWidgets import QLabel, QStyle, QVBoxLayout, QWidget
 
+from src.ui.dialogs.alert_dialog import AlertSeverity, show_alert
+
 
 class DropTargetWidget(QWidget):
     """Interactive drop target that also supports click-to-open."""
@@ -101,5 +103,14 @@ class DropTargetWidget(QWidget):
         self.style().unpolish(self)
         self.style().polish(self)
         self.update()
+
+        if not files:
+            show_alert(
+                self,
+                "No valid files were detected in the drop.",
+                severity=AlertSeverity.WARNING,
+                title="No files found",
+            )
+            return
 
         self.on_result(files)

--- a/src/ui/views/drop_target_widget.py
+++ b/src/ui/views/drop_target_widget.py
@@ -10,14 +10,16 @@ from PyQt6.QtWidgets import QLabel, QStyle, QVBoxLayout, QWidget
 class DropTargetWidget(QWidget):
     """Interactive drop target that also supports click-to-open."""
 
-    def __init__(self, on_click: Callable[[], None]) -> None:
+    def __init__(self, on_click: Callable[[], None], on_result: Callable[[list[str]], None]) -> None:
         """Initialize the drop target widget.
 
         Args:
             on_click: Callback invoked when the target is clicked.
+            on_result: Callback invoked with the list of dropped files.
         """
         super().__init__()
         self._on_click = on_click
+        self.on_result = on_result
         self.setMinimumHeight(300)
         self.setCursor(Qt.CursorShape.PointingHandCursor)
         self.setProperty("role", "drag-area")
@@ -55,7 +57,9 @@ class DropTargetWidget(QWidget):
     def mousePressEvent(self, event: QMouseEvent) -> None:
         """Trigger file-open callback on left click."""
         if event.button() == Qt.MouseButton.LeftButton:
-            self._on_click()
+            result = self._on_click()
+            if result:
+                self.on_result(result)
             event.accept()
             return
         super().mousePressEvent(event)

--- a/src/ui/views/drop_target_widget.py
+++ b/src/ui/views/drop_target_widget.py
@@ -10,7 +10,7 @@ from PyQt6.QtWidgets import QLabel, QStyle, QVBoxLayout, QWidget
 class DropTargetWidget(QWidget):
     """Interactive drop target that also supports click-to-open."""
 
-    def __init__(self, on_click: Callable[[], None], on_result: Callable[[list[str]], None]) -> None:
+    def __init__(self, on_click: Callable, on_result: Callable) -> None:
         """Initialize the drop target widget.
 
         Args:
@@ -23,7 +23,9 @@ class DropTargetWidget(QWidget):
         self.setMinimumHeight(300)
         self.setCursor(Qt.CursorShape.PointingHandCursor)
         self.setProperty("role", "drag-area")
+        self.setProperty("drag-hover", "false")
         self.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
+        self.setAcceptDrops(True)
         self._setup_ui()
 
     def _setup_ui(self) -> None:
@@ -63,3 +65,41 @@ class DropTargetWidget(QWidget):
             event.accept()
             return
         super().mousePressEvent(event)
+
+    def dragEnterEvent(self, event) -> None:  # type: ignore[override]
+        """Accept drag if it contains URLs (files)."""
+        mime = event.mimeData()
+        if mime.hasUrls():
+            event.acceptProposedAction()
+            self.setProperty("drag-hover", "true")
+            self.style().unpolish(self)
+            self.style().polish(self)
+            self.update()
+        else:
+            event.ignore()
+
+    def dragMoveEvent(self, event) -> None:  # type: ignore[override]
+        event.accept()
+
+    def dragLeaveEvent(self, event) -> None:  # type: ignore[override]
+        self.setProperty("drag-hover", "false")
+        self.style().unpolish(self)
+        self.style().polish(self)
+        self.update()
+
+    def dropEvent(self, event) -> None:  # type: ignore[override]
+        """Handle dropped files and call the on_drop callback if present."""
+        mime = event.mimeData()
+        files: list[str] = []
+        if mime.hasUrls():
+            for url in mime.urls():
+                if url.isLocalFile():
+                    files.append(url.toLocalFile())
+
+        # reset hover state
+        self.setProperty("drag-hover", "false")
+        self.style().unpolish(self)
+        self.style().polish(self)
+        self.update()
+
+        self.on_result(files)

--- a/src/ui/views/homepage.py
+++ b/src/ui/views/homepage.py
@@ -3,7 +3,12 @@
 from typing import Callable
 
 from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import QFileDialog, QLabel, QVBoxLayout, QWidget
+from PyQt6.QtWidgets import (
+    QFileDialog,
+    QLabel,
+    QVBoxLayout,
+    QWidget,
+)
 
 from src.ui.views.drop_target_widget import DropTargetWidget
 
@@ -11,12 +16,12 @@ from src.ui.views.drop_target_widget import DropTargetWidget
 class HomePage(QWidget):
     """Homepage view component."""
 
-    def __init__(self, transition_page_fn: Callable[[str], None]) -> None:
+    def __init__(self, transition_page_fn: Callable) -> None:
         """
         Initialize the homepage view.
 
         Args:
-            transition_page: Callback function for transitioning to other pages.
+            transition_page: Function for transitioning to other pages.
         """
         super().__init__()
         self.transition_page_fn = transition_page_fn
@@ -63,8 +68,10 @@ class HomePage(QWidget):
             image_filter,
         )
         return files
-    
+
     def handle_files(self, files: list[str]) -> None:
-        """Handle the list of files obtained from drag-and-drop or file dialog."""
-        from src.ui.main_window import Page  # Import here to avoid circular dependency
+        """Process the file paths obtained from drag-n-drop or file picker."""
+        # Import here to avoid circular dependency
+        from src.ui.main_window import Page
+
         self.transition_page_fn(Page.PLACEHOLDER, files=files)

--- a/src/ui/views/homepage.py
+++ b/src/ui/views/homepage.py
@@ -1,0 +1,111 @@
+"""Homepage view with title, interactive drag target, and file open button."""
+
+from typing import Callable
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QMouseEvent
+from PyQt6.QtWidgets import (
+    QLabel,
+    QStyle,
+    QVBoxLayout,
+    QWidget,
+)
+
+
+class DropTargetWidget(QWidget):
+    """Interactive drop target that also supports click-to-open."""
+
+    def __init__(self, on_click: Callable[[], None]) -> None:
+        """Initialize the drop target widget.
+
+        Args:
+            on_click: Callback invoked when the target is clicked.
+        """
+        super().__init__()
+        self._on_click = on_click
+        self.setMinimumHeight(300)
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.setProperty("role", "drag-area")
+        self.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
+        self._setup_ui()
+
+    def _setup_ui(self) -> None:
+        """Create icon, title, and helper text inside the target area."""
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(24, 24, 24, 24)
+        layout.setSpacing(10)
+
+        icon = QLabel()
+        icon.setProperty("role", "drag-icon")
+        open_icon_kind = QStyle.StandardPixmap.SP_DialogOpenButton
+        open_icon = self.style().standardIcon(open_icon_kind)
+        icon_pixmap = open_icon.pixmap(52, 52)
+        icon.setPixmap(icon_pixmap)
+        icon.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        title = QLabel("Drag Files Here")
+        title.setProperty("role", "drag-title")
+        title.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        subtitle = QLabel("or click to browse from your device")
+        subtitle.setProperty("role", "drag-subtitle")
+        subtitle.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        layout.addStretch()
+        layout.addWidget(icon)
+        layout.addWidget(title)
+        layout.addWidget(subtitle)
+        layout.addStretch()
+
+    def mousePressEvent(self, event: QMouseEvent) -> None:
+        """Trigger file-open callback on left click."""
+        if event.button() == Qt.MouseButton.LeftButton:
+            self._on_click()
+            event.accept()
+            return
+        super().mousePressEvent(event)
+
+
+class HomePage(QWidget):
+    """Homepage view component."""
+
+    def __init__(self, on_open_files: Callable[[], None]) -> None:
+        """
+        Initialize the homepage view.
+
+        Args:
+            on_open_files: Callback function when open files button is clicked.
+        """
+        super().__init__()
+        self.on_open_files = on_open_files
+        self._setup_ui()
+
+    def _setup_ui(self) -> None:
+        """Set up the UI components with responsive layout."""
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(40, 40, 40, 40)
+        layout.setSpacing(18)
+
+        # Logo title
+        logo_recat = '<span style="color: #FFFFFF;">Redact</span>'
+        logo_ai = '<span style="color: #C62828;">AI</span>'
+        title = QLabel(f"{logo_recat}{logo_ai}")
+        title.setProperty("role", "title")
+        title.setTextFormat(Qt.TextFormat.RichText)
+        title.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        # Subtitle
+        subtitle = QLabel("Your AI-powered redaction assistant")
+        subtitle.setProperty("role", "subtitle")
+        subtitle.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        # Drag area
+        file_drag_area = DropTargetWidget(self.on_open_files)
+
+        # Add components to layout with responsive spacing
+        layout.addStretch()
+        layout.addWidget(title)
+        layout.addWidget(subtitle)
+        layout.addStretch(1)
+        layout.addWidget(file_drag_area, 2)
+        layout.addStretch()

--- a/src/ui/views/homepage.py
+++ b/src/ui/views/homepage.py
@@ -3,7 +3,7 @@
 from typing import Callable
 
 from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import QLabel, QVBoxLayout, QWidget
+from PyQt6.QtWidgets import QFileDialog, QLabel, QVBoxLayout, QWidget
 
 from src.ui.views.drop_target_widget import DropTargetWidget
 
@@ -11,15 +11,15 @@ from src.ui.views.drop_target_widget import DropTargetWidget
 class HomePage(QWidget):
     """Homepage view component."""
 
-    def __init__(self, on_open_files: Callable[[], None]) -> None:
+    def __init__(self, transition_page_fn: Callable[[str], None]) -> None:
         """
         Initialize the homepage view.
 
         Args:
-            on_open_files: Callback function when open files button is clicked.
+            transition_page: Callback function for transitioning to other pages.
         """
         super().__init__()
-        self.on_open_files = on_open_files
+        self.transition_page_fn = transition_page_fn
         self._setup_ui()
 
     def _setup_ui(self) -> None:
@@ -42,7 +42,7 @@ class HomePage(QWidget):
         subtitle.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
         # Drag area
-        file_drag_area = DropTargetWidget(self.on_open_files)
+        file_drag_area = DropTargetWidget(self.open_files, self.handle_files)
 
         # Add components to layout with responsive spacing
         layout.addStretch()
@@ -51,3 +51,20 @@ class HomePage(QWidget):
         layout.addStretch(1)
         layout.addWidget(file_drag_area, 2)
         layout.addStretch()
+
+    def open_files(self) -> list[str]:
+        """Open a native file picker for selecting one or more image files."""
+        image_extensions = "*.png *.jpg *.jpeg *.bmp *.tif *.tiff *.webp"
+        image_filter = f"Images ({image_extensions});;All Files (*)"
+        files, _ = QFileDialog.getOpenFileNames(
+            self,
+            "Open Images",
+            "",
+            image_filter,
+        )
+        return files
+    
+    def handle_files(self, files: list[str]) -> None:
+        """Handle the list of files obtained from drag-and-drop or file dialog."""
+        from src.ui.main_window import Page  # Import here to avoid circular dependency
+        self.transition_page_fn(Page.PLACEHOLDER, files=files)

--- a/src/ui/views/homepage.py
+++ b/src/ui/views/homepage.py
@@ -3,67 +3,9 @@
 from typing import Callable
 
 from PyQt6.QtCore import Qt
-from PyQt6.QtGui import QMouseEvent
-from PyQt6.QtWidgets import (
-    QLabel,
-    QStyle,
-    QVBoxLayout,
-    QWidget,
-)
+from PyQt6.QtWidgets import QLabel, QVBoxLayout, QWidget
 
-
-class DropTargetWidget(QWidget):
-    """Interactive drop target that also supports click-to-open."""
-
-    def __init__(self, on_click: Callable[[], None]) -> None:
-        """Initialize the drop target widget.
-
-        Args:
-            on_click: Callback invoked when the target is clicked.
-        """
-        super().__init__()
-        self._on_click = on_click
-        self.setMinimumHeight(300)
-        self.setCursor(Qt.CursorShape.PointingHandCursor)
-        self.setProperty("role", "drag-area")
-        self.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
-        self._setup_ui()
-
-    def _setup_ui(self) -> None:
-        """Create icon, title, and helper text inside the target area."""
-        layout = QVBoxLayout(self)
-        layout.setContentsMargins(24, 24, 24, 24)
-        layout.setSpacing(10)
-
-        icon = QLabel()
-        icon.setProperty("role", "drag-icon")
-        open_icon_kind = QStyle.StandardPixmap.SP_DialogOpenButton
-        open_icon = self.style().standardIcon(open_icon_kind)
-        icon_pixmap = open_icon.pixmap(52, 52)
-        icon.setPixmap(icon_pixmap)
-        icon.setAlignment(Qt.AlignmentFlag.AlignCenter)
-
-        title = QLabel("Drag Files Here")
-        title.setProperty("role", "drag-title")
-        title.setAlignment(Qt.AlignmentFlag.AlignCenter)
-
-        subtitle = QLabel("or click to browse from your device")
-        subtitle.setProperty("role", "drag-subtitle")
-        subtitle.setAlignment(Qt.AlignmentFlag.AlignCenter)
-
-        layout.addStretch()
-        layout.addWidget(icon)
-        layout.addWidget(title)
-        layout.addWidget(subtitle)
-        layout.addStretch()
-
-    def mousePressEvent(self, event: QMouseEvent) -> None:
-        """Trigger file-open callback on left click."""
-        if event.button() == Qt.MouseButton.LeftButton:
-            self._on_click()
-            event.accept()
-            return
-        super().mousePressEvent(event)
+from src.ui.views.drop_target_widget import DropTargetWidget
 
 
 class HomePage(QWidget):

--- a/src/ui/views/homepage.py
+++ b/src/ui/views/homepage.py
@@ -54,8 +54,8 @@ class HomePage(QWidget):
         layout.addWidget(title)
         layout.addWidget(subtitle)
         layout.addStretch(1)
-        layout.addWidget(file_drag_area, 2)
-        layout.addStretch()
+        layout.addWidget(file_drag_area)
+        layout.addStretch(2)
 
     def open_files(self) -> list[str]:
         """Open a native file picker for selecting one or more image files."""

--- a/src/ui/views/placeholder.py
+++ b/src/ui/views/placeholder.py
@@ -1,0 +1,51 @@
+"""Placeholder view for content in development."""
+
+from typing import Callable
+
+from PyQt6.QtWidgets import QWidget, QVBoxLayout, QLabel, QPushButton
+from PyQt6.QtCore import Qt
+
+
+class PlaceholderView(QWidget):
+    """Placeholder view for pages in development."""
+
+    def __init__(self, on_back: Callable[[], None]) -> None:
+        """
+        Initialize the placeholder view.
+
+        Args:
+            on_back: Callback function when back button is clicked.
+        """
+        super().__init__()
+        self.on_back = on_back
+        self._setup_ui()
+
+    def _setup_ui(self) -> None:
+        """Set up the UI components."""
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(40, 40, 40, 40)
+        layout.setSpacing(16)
+
+        # Title
+        title = QLabel("Coming Soon")
+        title.setProperty("role", "title")
+        title.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        # Description
+        description = QLabel("This feature is coming soon...")
+        description.setProperty("role", "subtitle")
+        description.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        # Back button
+        back_button = QPushButton("Back to Home")
+        back_button.setProperty("role", "primary")
+        back_button.setMinimumWidth(220)
+        back_button.clicked.connect(self.on_back)
+
+        # Add components to layout
+        layout.addStretch()
+        layout.addWidget(title)
+        layout.addWidget(description)
+        layout.addStretch()
+        layout.addWidget(back_button, 0, Qt.AlignmentFlag.AlignHCenter)
+        layout.addStretch()

--- a/src/ui/views/placeholder.py
+++ b/src/ui/views/placeholder.py
@@ -18,7 +18,16 @@ class PlaceholderView(QWidget):
         """
         super().__init__()
         self.on_back = on_back
+        self.launch_extra: dict[str, object] = {}
         self._setup_ui()
+
+    def setLaunchExtra(self, **kwargs: object) -> None:
+        """Set extra launch parameters for this page.
+
+        Args:
+            **kwargs: Additional parameters passed from navigation.
+        """
+        self.launch_extra = kwargs
 
     def _setup_ui(self) -> None:
         """Set up the UI components."""

--- a/src/ui/views/placeholder.py
+++ b/src/ui/views/placeholder.py
@@ -2,8 +2,8 @@
 
 from typing import Callable
 
-from PyQt6.QtWidgets import QWidget, QVBoxLayout, QLabel, QPushButton
 from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import QLabel, QPushButton, QVBoxLayout, QWidget
 
 
 class PlaceholderView(QWidget):


### PR DESCRIPTION
__Description__
This PR establishes the core frontend architecture and initial user flow for the RedactAI desktop application using PyQt6. It introduces the main landing screen, handles local file ingestion (both via drag-and-drop and OS-native dialogs), and sets up the page management system to route users to the next steps in the pipeline.
__Key Changes:__
•	Main Menu Interface: Built the primary landing UI with a modern, dark-themed aesthetic.
•	Custom QSS Styling: Applied global styling via a custom .qss stylesheet to handle rounded corners, color palettes (dark backgrounds with red accents), and button hover/pressed states.
•	Drag & Drop Ingestion: Overrode dragEnterEvent and dropEvent on the central target widget. It now visually reacts to dragged items and filters for supported image MIME types (e.g., PNG, JPG).
•	Native File Picker: Native file picker support as an alternative for drag and drop importing.
•	Page Management (Routing): Implemented a QStackedWidget to manage UI state. The app can now cleanly transition from the "Main Menu" view to subsequent processing views without spawning new windows.
•	Data Passing Mechanism: Established the logic to capture the selected file paths (from either drag-and-drop or the file picker) and successfully pass that data payload to the next page in the stack for processing.
__Testing:__
Manual testing and debug inspection to verify features