### PR TITLE
feat: Bounding Box Blur And Pixel Manipulation (Issue #9)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "black>=26.3.1",
     "flake8>=7.3.0",
     "isort>=5.13.0",
+    "numpy>=2.3.4",
     "opencv-python-headless>=4.10.0",
     "Pillow>=11.0.0",
     "pyqt6>=6.11.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "black>=26.3.1",
     "flake8>=7.3.0",
     "isort>=5.13.0",
+    "opencv-python-headless>=4.10.0",
     "Pillow>=11.0.0",
     "pyqt6>=6.11.0",
     "pytesseract>=0.3.10",

--- a/src/redactEngine/__init__.py
+++ b/src/redactEngine/__init__.py
@@ -1,0 +1,5 @@
+"""Redaction engine public API."""
+
+from src.redactEngine.redactor import RedactionTarget, RedactionType, apply_redactions
+
+__all__ = ["RedactionType", "RedactionTarget", "apply_redactions"]

--- a/src/redactEngine/redactor.py
+++ b/src/redactEngine/redactor.py
@@ -24,7 +24,7 @@ class RedactionTarget:
     """Single redaction instruction for a rectangular image region."""
 
     location: BoundingBox
-    type: RedactionType
+    redaction_type: RedactionType
 
 
 def _clamp_bbox(
@@ -71,7 +71,11 @@ def apply_redactions(image: Image.Image, targets: list[RedactionTarget]) -> Imag
 
     Returns:
         A new ``PIL.Image`` with the requested regions permanently modified.
+        The returned image preserves the original image mode and alpha channel.
     """
+    original_mode = image.mode
+    alpha_channel = image.getchannel("A") if "A" in image.getbands() else None
+
     rgb_array = np.array(image.convert("RGB"), copy=True)
     bgr_array = cv2.cvtColor(rgb_array, cv2.COLOR_RGB2BGR)
     image_height, image_width = bgr_array.shape[:2]
@@ -83,16 +87,21 @@ def apply_redactions(image: Image.Image, targets: list[RedactionTarget]) -> Imag
 
         x1, y1, x2, y2 = clamped
 
-        if target.type == RedactionType.BLACK_BAR:
+        if target.redaction_type == RedactionType.BLACK_BAR:
             bgr_array[y1:y2, x1:x2] = (0, 0, 0)
             continue
 
-        if target.type == RedactionType.PIXELATE:
+        if target.redaction_type == RedactionType.PIXELATE:
             region = bgr_array[y1:y2, x1:x2]
             bgr_array[y1:y2, x1:x2] = _apply_heavy_pixelation(region)
             continue
 
-        raise ValueError(f"Unsupported redaction type: {target.type}")
+        raise ValueError(f"Unsupported redaction type: {target.redaction_type}")
 
     redacted_rgb = cv2.cvtColor(bgr_array, cv2.COLOR_BGR2RGB)
-    return Image.fromarray(redacted_rgb)
+    redacted_image = Image.fromarray(redacted_rgb, mode="RGB")
+
+    if alpha_channel is not None:
+        redacted_image.putalpha(alpha_channel)
+
+    return redacted_image.convert(original_mode)

--- a/src/redactEngine/redactor.py
+++ b/src/redactEngine/redactor.py
@@ -1,0 +1,98 @@
+"""Image redaction helpers implemented with OpenCV."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+import cv2
+import numpy as np
+from PIL import Image
+
+from src.ai.types import BoundingBox
+
+
+class RedactionType(str, Enum):
+    """Supported redaction styles."""
+
+    BLACK_BAR = "black_bar"
+    PIXELATE = "pixelate"
+
+
+@dataclass(frozen=True, slots=True)
+class RedactionTarget:
+    """Single redaction instruction for a rectangular image region."""
+
+    location: BoundingBox
+    type: RedactionType
+
+
+def _clamp_bbox(
+    location: BoundingBox, width: int, height: int
+) -> tuple[int, int, int, int] | None:
+    """Clamp a bounding box to image dimensions and return x1, y1, x2, y2."""
+    if location.width <= 0 or location.height <= 0:
+        return None
+
+    x1 = max(0, location.x)
+    y1 = max(0, location.y)
+    x2 = min(width, location.x + location.width)
+    y2 = min(height, location.y + location.height)
+
+    if x1 >= x2 or y1 >= y2:
+        return None
+    return x1, y1, x2, y2
+
+
+def _apply_heavy_pixelation(region: np.ndarray) -> np.ndarray:
+    """Apply strong pixelation by aggressive downscale/upscale."""
+    region_height, region_width = region.shape[:2]
+    downscale_width = max(1, region_width // 16)
+    downscale_height = max(1, region_height // 16)
+
+    small = cv2.resize(
+        region,
+        (downscale_width, downscale_height),
+        interpolation=cv2.INTER_LINEAR,
+    )
+    return cv2.resize(
+        small,
+        (region_width, region_height),
+        interpolation=cv2.INTER_NEAREST,
+    )
+
+
+def apply_redactions(image: Image.Image, targets: list[RedactionTarget]) -> Image.Image:
+    """Apply rectangle-based redactions and return a new image.
+
+    Args:
+        image: Source image.
+        targets: Redaction instructions with location and type.
+
+    Returns:
+        A new ``PIL.Image`` with the requested regions permanently modified.
+    """
+    rgb_array = np.array(image.convert("RGB"), copy=True)
+    bgr_array = cv2.cvtColor(rgb_array, cv2.COLOR_RGB2BGR)
+    image_height, image_width = bgr_array.shape[:2]
+
+    for target in targets:
+        clamped = _clamp_bbox(target.location, image_width, image_height)
+        if clamped is None:
+            continue
+
+        x1, y1, x2, y2 = clamped
+
+        if target.type == RedactionType.BLACK_BAR:
+            bgr_array[y1:y2, x1:x2] = (0, 0, 0)
+            continue
+
+        if target.type == RedactionType.PIXELATE:
+            region = bgr_array[y1:y2, x1:x2]
+            bgr_array[y1:y2, x1:x2] = _apply_heavy_pixelation(region)
+            continue
+
+        raise ValueError(f"Unsupported redaction type: {target.type}")
+
+    redacted_rgb = cv2.cvtColor(bgr_array, cv2.COLOR_BGR2RGB)
+    return Image.fromarray(redacted_rgb)

--- a/tests/redactEngine/test_redactor.py
+++ b/tests/redactEngine/test_redactor.py
@@ -1,0 +1,76 @@
+"""Tests for OpenCV-based redaction operations."""
+
+from __future__ import annotations
+
+import numpy as np
+from PIL import Image
+
+from src.ai.types import BoundingBox
+from src.redactEngine.redactor import RedactionTarget, RedactionType, apply_redactions
+
+
+def _make_gradient_image(width: int = 64, height: int = 64) -> Image.Image:
+    """Create a deterministic image with high local detail for pixelation tests."""
+    x = np.arange(width, dtype=np.uint16)
+    y = np.arange(height, dtype=np.uint16)[:, None]
+    red = ((x + y) % 256).astype(np.uint8)
+    green = ((x * 3 + y * 5) % 256).astype(np.uint8)
+    blue = ((x * 7 + y * 11) % 256).astype(np.uint8)
+    rgb = np.stack([red, green, blue], axis=-1)
+    return Image.fromarray(rgb, mode="RGB")
+
+
+def test_black_bar_only_affects_target_region() -> None:
+    image = _make_gradient_image()
+    original = np.array(image)
+
+    target = RedactionTarget(
+        location=BoundingBox(x=10, y=12, width=20, height=16),
+        type=RedactionType.BLACK_BAR,
+    )
+    redacted = np.array(apply_redactions(image, [target]))
+
+    assert np.array_equal(redacted[12:28, 10:30], np.zeros((16, 20, 3), dtype=np.uint8))
+
+    outside_original = original.copy()
+    outside_redacted = redacted.copy()
+    outside_original[12:28, 10:30] = 0
+    outside_redacted[12:28, 10:30] = 0
+    assert np.array_equal(outside_original, outside_redacted)
+
+
+def test_pixelation_permanently_changes_target_region_only() -> None:
+    image = _make_gradient_image()
+    original = np.array(image)
+
+    target = RedactionTarget(
+        location=BoundingBox(x=8, y=8, width=40, height=40),
+        type=RedactionType.PIXELATE,
+    )
+    redacted = np.array(apply_redactions(image, [target]))
+
+    original_region = original[8:48, 8:48]
+    redacted_region = redacted[8:48, 8:48]
+
+    assert not np.array_equal(original_region, redacted_region)
+
+    outside_original = original.copy()
+    outside_redacted = redacted.copy()
+    outside_original[8:48, 8:48] = 0
+    outside_redacted[8:48, 8:48] = 0
+    assert np.array_equal(outside_original, outside_redacted)
+
+
+def test_out_of_bounds_bbox_is_clamped() -> None:
+    image = _make_gradient_image(width=16, height=16)
+    original = np.array(image)
+
+    target = RedactionTarget(
+        location=BoundingBox(x=12, y=12, width=20, height=20),
+        type=RedactionType.BLACK_BAR,
+    )
+    redacted = np.array(apply_redactions(image, [target]))
+
+    assert np.array_equal(redacted[12:16, 12:16], np.zeros((4, 4, 3), dtype=np.uint8))
+    assert np.array_equal(redacted[0:12, :], original[0:12, :])
+    assert np.array_equal(redacted[:, 0:12], original[:, 0:12])

--- a/tests/redactEngine/test_redactor.py
+++ b/tests/redactEngine/test_redactor.py
@@ -26,7 +26,7 @@ def test_black_bar_only_affects_target_region() -> None:
 
     target = RedactionTarget(
         location=BoundingBox(x=10, y=12, width=20, height=16),
-        type=RedactionType.BLACK_BAR,
+        redaction_type=RedactionType.BLACK_BAR,
     )
     redacted = np.array(apply_redactions(image, [target]))
 
@@ -45,7 +45,7 @@ def test_pixelation_permanently_changes_target_region_only() -> None:
 
     target = RedactionTarget(
         location=BoundingBox(x=8, y=8, width=40, height=40),
-        type=RedactionType.PIXELATE,
+        redaction_type=RedactionType.PIXELATE,
     )
     redacted = np.array(apply_redactions(image, [target]))
 
@@ -67,10 +67,27 @@ def test_out_of_bounds_bbox_is_clamped() -> None:
 
     target = RedactionTarget(
         location=BoundingBox(x=12, y=12, width=20, height=20),
-        type=RedactionType.BLACK_BAR,
+        redaction_type=RedactionType.BLACK_BAR,
     )
     redacted = np.array(apply_redactions(image, [target]))
 
     assert np.array_equal(redacted[12:16, 12:16], np.zeros((4, 4, 3), dtype=np.uint8))
     assert np.array_equal(redacted[0:12, :], original[0:12, :])
     assert np.array_equal(redacted[:, 0:12], original[:, 0:12])
+
+
+def test_apply_redactions_preserves_rgba_alpha_channel_and_mode() -> None:
+    rgb = _make_gradient_image(width=16, height=16)
+    alpha = Image.new("L", (16, 16), color=123)
+    image = rgb.copy()
+    image.putalpha(alpha)
+    original_alpha = np.array(image.getchannel("A"))
+
+    target = RedactionTarget(
+        location=BoundingBox(x=2, y=2, width=8, height=8),
+        redaction_type=RedactionType.BLACK_BAR,
+    )
+    redacted = apply_redactions(image, [target])
+
+    assert redacted.mode == "RGBA"
+    assert np.array_equal(np.array(redacted.getchannel("A")), original_alpha)

--- a/uv.lock
+++ b/uv.lock
@@ -446,6 +446,24 @@ wheels = [
 ]
 
 [[package]]
+name = "opencv-python-headless"
+version = "4.13.0.92"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/42/2310883be3b8826ac58c3f2787b9358a2d46923d61f88fedf930bc59c60c/opencv_python_headless-4.13.0.92-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:1a7d040ac656c11b8c38677cc8cccdc149f98535089dbe5b081e80a4e5903209", size = 46247192, upload-time = "2026-02-05T07:01:35.187Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/1e/6f9e38005a6f7f22af785df42a43139d0e20f169eb5787ce8be37ee7fcc9/opencv_python_headless-4.13.0.92-cp37-abi3-macosx_14_0_x86_64.whl", hash = "sha256:3e0a6f0a37994ec6ce5f59e936be21d5d6384a4556f2d2da9c2f9c5dc948394c", size = 32568914, upload-time = "2026-02-05T07:01:51.989Z" },
+    { url = "https://files.pythonhosted.org/packages/21/76/9417a6aef9def70e467a5bf560579f816148a4c658b7d525581b356eda9e/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c8cfc8e87ed452b5cecb9419473ee5560a989859fe1d10d1ce11ae87b09a2cb", size = 33703709, upload-time = "2026-02-05T10:24:46.469Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ce/bd17ff5772938267fd49716e94ca24f616ff4cb1ff4c6be13085108037be/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0525a3d2c0b46c611e2130b5fdebc94cf404845d8fa64d2f3a3b679572a5bd22", size = 56016764, upload-time = "2026-02-05T10:26:48.904Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b4/b7bcbf7c874665825a8c8e1097e93ea25d1f1d210a3e20d4451d01da30aa/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:eb60e36b237b1ebd40a912da5384b348df8ed534f6f644d8e0b4f103e272ba7d", size = 35010236, upload-time = "2026-02-05T10:28:11.031Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/33/b5db29a6c00eb8f50708110d8d453747ca125c8b805bc437b289dbdcc057/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0bd48544f77c68b2941392fcdf9bcd2b9cdf00e98cb8c29b2455d194763cf99e", size = 60391106, upload-time = "2026-02-05T10:30:14.236Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c3/52cfea47cd33e53e8c0fbd6e7c800b457245c1fda7d61660b4ffe9596a7f/opencv_python_headless-4.13.0.92-cp37-abi3-win32.whl", hash = "sha256:a7cf08e5b191f4ebb530791acc0825a7986e0d0dee2a3c491184bd8599848a4b", size = 30812232, upload-time = "2026-02-05T07:02:29.594Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/90/b338326131ccb2aaa3c2c85d00f41822c0050139a4bfe723cfd95455bd2d/opencv_python_headless-4.13.0.92-cp37-abi3-win_amd64.whl", hash = "sha256:77a82fe35ddcec0f62c15f2ba8a12ecc2ed4207c17b0902c7a3151ae29f37fb6", size = 40070414, upload-time = "2026-02-05T07:02:26.448Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -738,6 +756,8 @@ dependencies = [
     { name = "black" },
     { name = "flake8" },
     { name = "isort" },
+    { name = "numpy" },
+    { name = "opencv-python-headless" },
     { name = "pillow" },
     { name = "pyqt6" },
     { name = "pytesseract" },
@@ -751,6 +771,8 @@ requires-dist = [
     { name = "black", specifier = ">=26.3.1" },
     { name = "flake8", specifier = ">=7.3.0" },
     { name = "isort", specifier = ">=5.13.0" },
+    { name = "numpy", specifier = ">=2.3.4" },
+    { name = "opencv-python-headless", specifier = ">=4.10.0" },
     { name = "pillow", specifier = ">=11.0.0" },
     { name = "pyqt6", specifier = ">=6.11.0" },
     { name = "pytesseract", specifier = ">=0.3.10" },


### PR DESCRIPTION
This pull request introduces a new image redaction engine using OpenCV with a clear public API, and adds comprehensive tests to verify its correctness. The main changes include implementing the redaction logic, exposing the API, updating dependencies, and adding unit tests.

**Redaction engine implementation:**

* Added `src/redactEngine/redactor.py`, which implements image redaction using OpenCV. It supports two redaction types (`BLACK_BAR` and `PIXELATE`), defines the `RedactionTarget` dataclass, and provides the `apply_redactions` function to process images with a list of redaction instructions.
* Updated `pyproject.toml` to add `opencv-python-headless` as a dependency, required for OpenCV-based image processing.

**Public API and tests:**

* Added `src/redactEngine/__init__.py` to expose the public API (`RedactionType`, `RedactionTarget`, `apply_redactions`).
* Added `tests/redactEngine/test_redactor.py` with unit tests covering black bar and pixelation redactions, bounding box clamping, and ensuring modifications are limited to the target region.