### PR TITLE
feat/ui

### DIFF
--- a/src/persistance/config_manager.py
+++ b/src/persistance/config_manager.py
@@ -41,6 +41,7 @@ class ConfigManager:
             "confidence_threshold": 0.8,
             "output_format": "png",
             "allow_usage_statistics": False,
+            "is_first_launch": True,
             "redact_faces": True,
             "redact_phone_numbers": True,
             "redact_emails": True,

--- a/src/ui/dialogs/alert_dialog.py
+++ b/src/ui/dialogs/alert_dialog.py
@@ -152,7 +152,10 @@ def show_alert(
     severity: AlertSeverity | str = AlertSeverity.INFO,
     title: str | None = None,
 ) -> int:
-    """Display an alert dialog and return the modal result code."""
+    """Display an alert dialog and return the modal result code.
+
+    Return the result code of the dialog.
+    """
 
     dialog = AlertDialog(
         message,
@@ -169,10 +172,10 @@ def show_confirmation_dialog(
     *,
     severity: AlertSeverity | str = AlertSeverity.INFO,
     title: str | None = None,
-) -> bool:
+) -> int:
     """Display a confirmation dialog with 2 buttons.
 
-    Returns True if the user confirmed/allowed, False if they cancelled/rejected.
+    Returns the result code of the dialog.
     """
 
     buttons = [

--- a/src/ui/dialogs/alert_dialog.py
+++ b/src/ui/dialogs/alert_dialog.py
@@ -1,5 +1,6 @@
 """Reusable alert dialog for informational and warning messages."""
 
+from dataclasses import dataclass
 from enum import Enum
 
 from PyQt6.QtCore import Qt
@@ -21,6 +22,21 @@ class AlertSeverity(str, Enum):
     WARNING = "warning"
 
 
+class AlertButtonRole(str, Enum):
+    """Supported action roles for alert dialog buttons."""
+
+    CONFIRM = "confirm"
+    CANCEL = "cancel"
+
+
+@dataclass(frozen=True, slots=True)
+class AlertDialogButtonSpec:
+    """Configuration for a single alert dialog button."""
+
+    role: AlertButtonRole
+    text: str
+
+
 class AlertDialog(QDialog):
     """Small reusable popup for displaying alert messages."""
 
@@ -35,6 +51,7 @@ class AlertDialog(QDialog):
         *,
         severity: AlertSeverity | str = AlertSeverity.INFO,
         title: str | None = None,
+        buttons: list[AlertDialogButtonSpec] | None = None,
         parent: QWidget | None = None,
     ) -> None:
         super().__init__(parent)
@@ -44,7 +61,18 @@ class AlertDialog(QDialog):
         self.setObjectName("alertDialog")
         self.setProperty("role", "alert-dialog")
         self.setProperty("severity", self._severity.value)
-        self._setup_ui(message)
+        self._setup_ui(message, buttons or self._default_buttons())
+
+    @staticmethod
+    def _default_buttons() -> list[AlertDialogButtonSpec]:
+        """Return the default single-button layout."""
+
+        return [
+            AlertDialogButtonSpec(
+                role=AlertButtonRole.CANCEL,
+                text="Cancel",
+            )
+        ]
 
     @classmethod
     def _coerce_severity(cls, severity: AlertSeverity | str) -> AlertSeverity:
@@ -54,7 +82,7 @@ class AlertDialog(QDialog):
         normalized = str(severity).strip().lower()
         return AlertSeverity(normalized)
 
-    def _setup_ui(self, message: str) -> None:
+    def _setup_ui(self, message: str, buttons: list[AlertDialogButtonSpec]) -> None:
         layout = QVBoxLayout(self)
         layout.setContentsMargins(24, 24, 24, 24)
         layout.setSpacing(16)
@@ -93,12 +121,23 @@ class AlertDialog(QDialog):
         header_layout.addLayout(text_column, 1)
 
         button_box = QDialogButtonBox()
-        close_button = button_box.addButton(
-            "Close",
-            QDialogButtonBox.ButtonRole.RejectRole,
-        )
-        close_button.setProperty("role", "alert-close")
-        close_button.clicked.connect(self.close)
+        for index, button_spec in enumerate(buttons):
+            if button_spec.role is AlertButtonRole.CONFIRM:
+                qt_role = QDialogButtonBox.ButtonRole.AcceptRole
+                handler = self.accept
+                role_style = "confirm"
+            elif button_spec.role is AlertButtonRole.CANCEL:
+                qt_role = QDialogButtonBox.ButtonRole.RejectRole
+                handler = self.reject
+                role_style = "cancel"
+            else:  # pragma: no cover - defensive guard for future roles
+                raise ValueError(f"Unsupported button role: {button_spec.role!r}")
+
+            button = button_box.addButton(button_spec.text, qt_role)
+            button.setProperty("role", f"alert-{role_style}")
+            if index == 0:
+                button.setDefault(True)
+            button.clicked.connect(handler)
 
         layout.addLayout(header_layout)
         layout.addWidget(button_box, alignment=Qt.AlignmentFlag.AlignRight)
@@ -118,6 +157,39 @@ def show_alert(
     dialog = AlertDialog(
         message,
         severity=severity,
+        title=title,
+        parent=parent,
+    )
+    return dialog.exec()
+
+
+def show_confirmation_dialog(
+    parent: QWidget | None,
+    message: str,
+    *,
+    severity: AlertSeverity | str = AlertSeverity.INFO,
+    title: str | None = None,
+) -> bool:
+    """Display a confirmation dialog with "Confirm" and "Cancel" buttons.
+
+    Returns True if the user confirmed, False if they cancelled.
+    """
+
+    buttons = [
+        AlertDialogButtonSpec(
+            role=AlertButtonRole.CONFIRM,
+            text="Confirm",
+        ),
+        AlertDialogButtonSpec(
+            role=AlertButtonRole.CANCEL,
+            text="Cancel",
+        ),
+    ]
+
+    dialog = AlertDialog(
+        message,
+        severity=severity,
+        buttons=buttons,
         title=title,
         parent=parent,
     )

--- a/src/ui/dialogs/alert_dialog.py
+++ b/src/ui/dialogs/alert_dialog.py
@@ -170,19 +170,19 @@ def show_confirmation_dialog(
     severity: AlertSeverity | str = AlertSeverity.INFO,
     title: str | None = None,
 ) -> bool:
-    """Display a confirmation dialog with "Confirm" and "Cancel" buttons.
+    """Display a confirmation dialog with 2 buttons.
 
-    Returns True if the user confirmed, False if they cancelled.
+    Returns True if the user confirmed/allowed, False if they cancelled/rejected.
     """
 
     buttons = [
         AlertDialogButtonSpec(
             role=AlertButtonRole.CONFIRM,
-            text="Confirm",
+            text="Allow",
         ),
         AlertDialogButtonSpec(
             role=AlertButtonRole.CANCEL,
-            text="Cancel",
+            text="Decline",
         ),
     ]
 

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -2,9 +2,11 @@
 
 from enum import Enum
 
-from PyQt6.QtWidgets import QMainWindow, QStackedWidget
+from PyQt6.QtWidgets import QDialog, QMainWindow, QStackedWidget
 
+from src.persistance.config_manager import ConfigManager
 from src.persistance.resource_loader import ResourceLoader
+from src.ui.dialogs.alert_dialog import show_confirmation_dialog
 from src.ui.views.homepage import HomePage
 from src.ui.views.placeholder import PlaceholderView
 
@@ -46,6 +48,41 @@ class MainWindow(QMainWindow):
 
         # Show homepage first
         self.stacked_widget.setCurrentWidget(self.homepage)
+
+        # first launch analytics consent
+        if self._is_first_launch():
+            self._prompt_analytics_consent()
+
+            config_path = ConfigManager.get_default_save_directory() / "config.json"
+            config_manager = ConfigManager(config_path)
+            config_manager.load()
+            config_manager.set("is_first_launch", False)
+            config_manager.save()
+
+    def _is_first_launch(self) -> bool:
+        """Check if this is the first launch based on config."""
+        config_path = ConfigManager.get_default_save_directory() / "config.json"
+        config_manager = ConfigManager(config_path)
+        config_manager.load()
+        return config_manager.get("is_first_launch", True)
+
+    def _prompt_analytics_consent(self) -> None:
+        """Show the first-run analytics consent dialog once."""
+
+        dialog_result = show_confirmation_dialog(
+            self,
+            "Do you want to allow sending anonymous analytics?",
+            severity="info",
+            title="Analytics consent",
+        )
+        allowed_analytics = dialog_result == QDialog.DialogCode.Accepted
+        print(f"Analytics consent: {'allowed' if allowed_analytics else 'declined'}")
+
+        config_path = ConfigManager.get_default_save_directory() / "config.json"
+        config_manager = ConfigManager(config_path)
+        config_manager.load()
+        config_manager.set("allow_usage_statistics", allowed_analytics)
+        config_manager.save()
 
     def _apply_theme(self) -> None:
         """Load and apply the shared application theme."""

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -75,7 +75,6 @@ class MainWindow(QMainWindow):
             title="Analytics consent",
         )
         allowed_analytics = dialog_result == QDialog.DialogCode.Accepted
-        print(f"Analytics consent: {'allowed' if allowed_analytics else 'declined'}")
 
         config_path = ConfigManager.get_default_save_directory() / "config.json"
         config_manager = ConfigManager(config_path)

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -57,7 +57,6 @@ class MainWindow(QMainWindow):
             config_manager = ConfigManager(config_path)
             config_manager.load()
             config_manager.set("is_first_launch", False)
-            config_manager.save()
 
     def _is_first_launch(self) -> bool:
         """Check if this is the first launch based on config."""
@@ -82,7 +81,6 @@ class MainWindow(QMainWindow):
         config_manager = ConfigManager(config_path)
         config_manager.load()
         config_manager.set("allow_usage_statistics", allowed_analytics)
-        config_manager.save()
 
     def _apply_theme(self) -> None:
         """Load and apply the shared application theme."""

--- a/src/ui/styles/theme.qss
+++ b/src/ui/styles/theme.qss
@@ -83,6 +83,21 @@ QPushButton[role="alert-close"]:hover {
     background-color: #ff8c8c;
 }
 
+
+QPushButton[role="alert-confirm"] {
+    background-color: #6bf770;
+    color: #ffffff;
+    border: none;
+    border-radius: 6px;
+    padding: 8px 18px;
+    font-size: 14px;
+    font-weight: 600;
+}
+
+QPushButton[role="alert-confirm"]:hover {
+    background-color: #8cff96;
+}
+
 QLabel[role="drag-title"] {
     background: transparent;
     color: #ececec;

--- a/src/ui/styles/theme.qss
+++ b/src/ui/styles/theme.qss
@@ -69,7 +69,7 @@ QLabel[role="alert-icon"][severity="warning"] {
     background: transparent;
 }
 
-QPushButton[role="alert-close"] {
+QPushButton[role="alert-cancel"] {
     background-color: #f76b6b;
     color: #ffffff;
     border: none;
@@ -79,7 +79,7 @@ QPushButton[role="alert-close"] {
     font-weight: 600;
 }
 
-QPushButton[role="alert-close"]:hover {
+QPushButton[role="alert-cancel"]:hover {
     background-color: #ff8c8c;
 }
 

--- a/tests/persistance/test_config_manager.py
+++ b/tests/persistance/test_config_manager.py
@@ -13,6 +13,7 @@ def test_set_persists(tmp_path):
     assert cm.get("redact_faces") is True
     assert cm.get("redact_phone_numbers") is True
     assert cm.get("redact_emails") is True
+    assert cm.get("is_first_launch") is True
 
 
 def test_default_save_directory():


### PR DESCRIPTION
__Description:__
 This PR adds a first-launch analytics consent flow and updated the reusable alert dialog to with support configurable buttons. Key 

__Changes__: 
- Add support for multi button dialog popups.
- First launch execution: Allow code to run only on first launch.
- Ask user to send analytics: On first launch ask the user for permission to send usage statistics and save this preference.


__Testing:__
 Manual testing and debug inspection to verify features.