### PR TITLE
feat: submit redaction analytics to Google Form (#17)

### DIFF
--- a/src/persistance/__init__.py
+++ b/src/persistance/__init__.py
@@ -1,5 +1,6 @@
 """Data persistence and resource management for RedactAI."""
 
+from src.persistance.analytics import submit_analytics
 from src.persistance.image_reader import (
     ImageBatchReadResult,
     ImageReadError,
@@ -7,4 +8,10 @@ from src.persistance.image_reader import (
     read_images,
 )
 
-__all__ = ["ImageReadError", "ImageBatchReadResult", "read_image", "read_images"]
+__all__ = [
+    "ImageBatchReadResult",
+    "ImageReadError",
+    "read_image",
+    "read_images",
+    "submit_analytics",
+]

--- a/src/persistance/analytics.py
+++ b/src/persistance/analytics.py
@@ -1,14 +1,14 @@
 """Analytics submission for RedactAI.
 
-Submits a redaction-count and a test-mode flag to a developer-owned Google Form.
-The submission is gated on user consent: if consent is not granted, the function
-returns immediately and makes no network call.
+Submits a redaction count to a developer-owned Google Form. The submission is
+gated on user consent: if consent is not granted, the function returns
+immediately and makes no network call.
 
-The form URL and field IDs live in :mod:`src.persistance.analytics_config` and
-ship inside the binary. Setting any of those constants to an empty string
-disables analytics submission (the function returns ``False`` without making a
-network call). The submission carries only the integer count and the boolean
-flag; no image content or other identifying information is transmitted.
+The form URL and field ID live in :mod:`src.persistance.analytics_config` and
+ship inside the binary. Setting either constant to an empty string disables
+analytics submission (the function returns ``False`` without making a network
+call). The submission carries only the integer count; no image content or
+other identifying information is transmitted.
 """
 
 from __future__ import annotations
@@ -22,7 +22,6 @@ from src.persistance import analytics_config
 
 def submit_analytics(
     redaction_count: int,
-    test_mode: bool,
     consent_granted: bool,
     *,
     timeout: float = 5.0,
@@ -31,7 +30,8 @@ def submit_analytics(
 
     Args:
         redaction_count: The number of redactions applied in the session.
-        test_mode: Whether the application is running in test mode.
+            Must be non-negative; negative values cause the function to return
+            ``False`` without making a network call.
         consent_granted: Whether the user has granted consent for analytics.
             When ``False`` the function returns immediately and performs no
             side effect (no config reads, no logging, no network call).
@@ -39,24 +39,23 @@ def submit_analytics(
 
     Returns:
         ``True`` when the form accepted the submission with a 2xx status,
-        ``False`` otherwise (consent denied, config blank, network error,
-        or non-2xx response).
+        ``False`` otherwise (consent denied, negative count, config blank,
+        network error, or non-2xx response).
     """
     if not consent_granted:
         return False
 
-    form_url = analytics_config.FORM_URL
-    entry_count = analytics_config.ENTRY_COUNT
-    entry_test_mode = analytics_config.ENTRY_TEST_MODE
-    if not form_url or not entry_count or not entry_test_mode:
+    if redaction_count < 0:
         return False
 
-    payload = urllib.parse.urlencode(
-        {
-            entry_count: str(int(redaction_count)),
-            entry_test_mode: "true" if test_mode else "false",
-        }
-    ).encode("utf-8")
+    form_url = analytics_config.FORM_URL
+    entry_count = analytics_config.ENTRY_COUNT
+    if not form_url or not entry_count:
+        return False
+
+    payload = urllib.parse.urlencode({entry_count: str(int(redaction_count))}).encode(
+        "utf-8"
+    )
 
     request = urllib.request.Request(
         url=form_url,

--- a/src/persistance/analytics.py
+++ b/src/persistance/analytics.py
@@ -1,0 +1,75 @@
+"""Analytics submission for RedactAI.
+
+Submits a redaction-count and a test-mode flag to a developer-owned Google Form.
+The submission is gated on user consent: if consent is not granted, the function
+returns immediately and makes no network call.
+
+The form URL and field IDs live in :mod:`src.persistance.analytics_config` and
+ship inside the binary. Setting any of those constants to an empty string
+disables analytics submission (the function returns ``False`` without making a
+network call). The submission carries only the integer count and the boolean
+flag; no image content or other identifying information is transmitted.
+"""
+
+from __future__ import annotations
+
+import urllib.error
+import urllib.parse
+import urllib.request
+
+from src.persistance import analytics_config
+
+
+def submit_analytics(
+    redaction_count: int,
+    test_mode: bool,
+    consent_granted: bool,
+    *,
+    timeout: float = 5.0,
+) -> bool:
+    """Submit redaction analytics to the configured Google Form.
+
+    Args:
+        redaction_count: The number of redactions applied in the session.
+        test_mode: Whether the application is running in test mode.
+        consent_granted: Whether the user has granted consent for analytics.
+            When ``False`` the function returns immediately and performs no
+            side effect (no config reads, no logging, no network call).
+        timeout: Per-request timeout in seconds for the HTTP POST.
+
+    Returns:
+        ``True`` when the form accepted the submission with a 2xx status,
+        ``False`` otherwise (consent denied, config blank, network error,
+        or non-2xx response).
+    """
+    if not consent_granted:
+        return False
+
+    form_url = analytics_config.FORM_URL
+    entry_count = analytics_config.ENTRY_COUNT
+    entry_test_mode = analytics_config.ENTRY_TEST_MODE
+    if not form_url or not entry_count or not entry_test_mode:
+        return False
+
+    payload = urllib.parse.urlencode(
+        {
+            entry_count: str(int(redaction_count)),
+            entry_test_mode: "true" if test_mode else "false",
+        }
+    ).encode("utf-8")
+
+    request = urllib.request.Request(
+        url=form_url,
+        data=payload,
+        method="POST",
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            status = getattr(response, "status", None)
+            if status is None:
+                status = response.getcode()
+            return 200 <= int(status) < 300
+    except urllib.error.URLError, TimeoutError, OSError:
+        return False

--- a/src/persistance/analytics_config.py
+++ b/src/persistance/analytics_config.py
@@ -7,7 +7,8 @@ anyway. Setting any value to an empty string disables analytics submission:
 """
 
 FORM_URL: str = (
-    "https://docs.google.com/forms/d/e/" "1FAIpQLScPVrw-dDh-9_W9RimXuP9G9cF9cZl6UmPToaxAX212gNbVIg/formResponse"
+    "https://docs.google.com/forms/d/e/"
+    "1FAIpQLScPVrw-dDh-9_W9RimXuP9G9cF9cZl6UmPToaxAX212gNbVIg/formResponse"
 )
 ENTRY_COUNT: str = "entry.1704973568"
 ENTRY_TEST_MODE: str = "entry.2112608349"

--- a/src/persistance/analytics_config.py
+++ b/src/persistance/analytics_config.py
@@ -1,0 +1,13 @@
+"""Analytics endpoint configuration.
+
+The Google Form URL and field IDs are committed to the repo deliberately --
+they are effectively a public write token that has to ship inside the binary
+anyway. Setting any value to an empty string disables analytics submission:
+``submit_analytics`` will return ``False`` without making a network call.
+"""
+
+FORM_URL: str = (
+    "https://docs.google.com/forms/d/e/" "1FAIpQLScPVrw-dDh-9_W9RimXuP9G9cF9cZl6UmPToaxAX212gNbVIg/formResponse"
+)
+ENTRY_COUNT: str = "entry.1704973568"
+ENTRY_TEST_MODE: str = "entry.2112608349"

--- a/src/persistance/analytics_config.py
+++ b/src/persistance/analytics_config.py
@@ -1,8 +1,8 @@
 """Analytics endpoint configuration.
 
-The Google Form URL and field IDs are committed to the repo deliberately --
+The Google Form URL and field ID are committed to the repo deliberately --
 they are effectively a public write token that has to ship inside the binary
-anyway. Setting any value to an empty string disables analytics submission:
+anyway. Setting either value to an empty string disables analytics submission:
 ``submit_analytics`` will return ``False`` without making a network call.
 """
 
@@ -11,4 +11,3 @@ FORM_URL: str = (
     "1FAIpQLScPVrw-dDh-9_W9RimXuP9G9cF9cZl6UmPToaxAX212gNbVIg/formResponse"
 )
 ENTRY_COUNT: str = "entry.1704973568"
-ENTRY_TEST_MODE: str = "entry.2112608349"

--- a/tests/persistance/test_analytics.py
+++ b/tests/persistance/test_analytics.py
@@ -44,16 +44,22 @@ class TestConsentGate:
     def test_no_network_call_when_consent_denied(self, monkeypatch):
         _set_config(monkeypatch)
         with patch("src.persistance.analytics.urllib.request.urlopen") as mock_urlopen:
-            result = submit_analytics(redaction_count=7, test_mode=False, consent_granted=False)
+            result = submit_analytics(
+                redaction_count=7, test_mode=False, consent_granted=False
+            )
         assert result is False
         mock_urlopen.assert_not_called()
 
-    def test_returns_false_when_consent_denied_even_with_config_blank(self, monkeypatch):
+    def test_returns_false_when_consent_denied_even_with_config_blank(
+        self, monkeypatch
+    ):
         monkeypatch.setattr(analytics_config, "FORM_URL", "")
         monkeypatch.setattr(analytics_config, "ENTRY_COUNT", "")
         monkeypatch.setattr(analytics_config, "ENTRY_TEST_MODE", "")
         with patch("src.persistance.analytics.urllib.request.urlopen") as mock_urlopen:
-            result = submit_analytics(redaction_count=1, test_mode=True, consent_granted=False)
+            result = submit_analytics(
+                redaction_count=1, test_mode=True, consent_granted=False
+            )
         assert result is False
         mock_urlopen.assert_not_called()
 
@@ -65,7 +71,9 @@ class TestSuccessfulSubmission:
             "src.persistance.analytics.urllib.request.urlopen",
             return_value=_make_response(200),
         ) as mock_urlopen:
-            result = submit_analytics(redaction_count=5, test_mode=True, consent_granted=True)
+            result = submit_analytics(
+                redaction_count=5, test_mode=True, consent_granted=True
+            )
 
         assert result is True
         mock_urlopen.assert_called_once()
@@ -87,7 +95,9 @@ class TestSuccessfulSubmission:
             "src.persistance.analytics.urllib.request.urlopen",
             return_value=_make_response(200),
         ) as mock_urlopen:
-            submit_analytics(redaction_count=0, test_mode=test_mode, consent_granted=True)
+            submit_analytics(
+                redaction_count=0, test_mode=test_mode, consent_granted=True
+            )
         body = _decode_post_body(mock_urlopen.call_args)
         assert body[FAKE_ENTRY_TEST_MODE] == expected
 
@@ -107,7 +117,9 @@ class TestSuccessfulSubmission:
             "src.persistance.analytics.urllib.request.urlopen",
             return_value=_make_response(200),
         ) as mock_urlopen:
-            submit_analytics(redaction_count=1, test_mode=False, consent_granted=True, timeout=2.5)
+            submit_analytics(
+                redaction_count=1, test_mode=False, consent_granted=True, timeout=2.5
+            )
         assert mock_urlopen.call_args.kwargs.get("timeout") == 2.5
 
 
@@ -120,7 +132,9 @@ class TestMissingConfiguration:
         _set_config(monkeypatch)
         monkeypatch.setattr(analytics_config, blank_attr, "")
         with patch("src.persistance.analytics.urllib.request.urlopen") as mock_urlopen:
-            result = submit_analytics(redaction_count=3, test_mode=False, consent_granted=True)
+            result = submit_analytics(
+                redaction_count=3, test_mode=False, consent_granted=True
+            )
         assert result is False
         mock_urlopen.assert_not_called()
 
@@ -132,7 +146,9 @@ class TestErrorHandling:
             "src.persistance.analytics.urllib.request.urlopen",
             side_effect=urllib.error.URLError("boom"),
         ):
-            result = submit_analytics(redaction_count=1, test_mode=True, consent_granted=True)
+            result = submit_analytics(
+                redaction_count=1, test_mode=True, consent_granted=True
+            )
         assert result is False
 
     def test_returns_false_on_timeout(self, monkeypatch):
@@ -141,7 +157,9 @@ class TestErrorHandling:
             "src.persistance.analytics.urllib.request.urlopen",
             side_effect=TimeoutError("slow"),
         ):
-            result = submit_analytics(redaction_count=1, test_mode=True, consent_granted=True)
+            result = submit_analytics(
+                redaction_count=1, test_mode=True, consent_granted=True
+            )
         assert result is False
 
     def test_returns_false_on_os_error(self, monkeypatch):
@@ -150,7 +168,9 @@ class TestErrorHandling:
             "src.persistance.analytics.urllib.request.urlopen",
             side_effect=OSError("dns"),
         ):
-            result = submit_analytics(redaction_count=1, test_mode=True, consent_granted=True)
+            result = submit_analytics(
+                redaction_count=1, test_mode=True, consent_granted=True
+            )
         assert result is False
 
     def test_returns_false_on_non_2xx_status(self, monkeypatch):
@@ -159,5 +179,7 @@ class TestErrorHandling:
             "src.persistance.analytics.urllib.request.urlopen",
             return_value=_make_response(500),
         ):
-            result = submit_analytics(redaction_count=1, test_mode=True, consent_granted=True)
+            result = submit_analytics(
+                redaction_count=1, test_mode=True, consent_granted=True
+            )
         assert result is False

--- a/tests/persistance/test_analytics.py
+++ b/tests/persistance/test_analytics.py
@@ -13,13 +13,11 @@ from src.persistance.analytics import submit_analytics
 
 FAKE_FORM_URL = "https://docs.google.com/forms/d/e/FAKE/formResponse"
 FAKE_ENTRY_COUNT = "entry.111111111"
-FAKE_ENTRY_TEST_MODE = "entry.222222222"
 
 
 def _set_config(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(analytics_config, "FORM_URL", FAKE_FORM_URL)
     monkeypatch.setattr(analytics_config, "ENTRY_COUNT", FAKE_ENTRY_COUNT)
-    monkeypatch.setattr(analytics_config, "ENTRY_TEST_MODE", FAKE_ENTRY_TEST_MODE)
 
 
 def _make_response(status: int) -> MagicMock:
@@ -40,13 +38,21 @@ def _decode_post_body(call) -> dict[str, str]:
     return {k: v[0] for k, v in urllib.parse.parse_qs(body).items()}
 
 
+def _get_header_ci(request, name: str) -> str | None:
+    # urllib.request.Request normalises header keys via str.capitalize(),
+    # so an exact-case lookup can miss; match case-insensitively here.
+    target = name.lower()
+    for key, value in request.headers.items():
+        if key.lower() == target:
+            return value
+    return None
+
+
 class TestConsentGate:
     def test_no_network_call_when_consent_denied(self, monkeypatch):
         _set_config(monkeypatch)
         with patch("src.persistance.analytics.urllib.request.urlopen") as mock_urlopen:
-            result = submit_analytics(
-                redaction_count=7, test_mode=False, consent_granted=False
-            )
+            result = submit_analytics(redaction_count=7, consent_granted=False)
         assert result is False
         mock_urlopen.assert_not_called()
 
@@ -55,51 +61,33 @@ class TestConsentGate:
     ):
         monkeypatch.setattr(analytics_config, "FORM_URL", "")
         monkeypatch.setattr(analytics_config, "ENTRY_COUNT", "")
-        monkeypatch.setattr(analytics_config, "ENTRY_TEST_MODE", "")
         with patch("src.persistance.analytics.urllib.request.urlopen") as mock_urlopen:
-            result = submit_analytics(
-                redaction_count=1, test_mode=True, consent_granted=False
-            )
+            result = submit_analytics(redaction_count=1, consent_granted=False)
         assert result is False
         mock_urlopen.assert_not_called()
 
 
 class TestSuccessfulSubmission:
-    def test_posts_count_and_test_mode_and_returns_true(self, monkeypatch):
+    def test_posts_count_and_returns_true(self, monkeypatch):
         _set_config(monkeypatch)
         with patch(
             "src.persistance.analytics.urllib.request.urlopen",
             return_value=_make_response(200),
         ) as mock_urlopen:
-            result = submit_analytics(
-                redaction_count=5, test_mode=True, consent_granted=True
-            )
+            result = submit_analytics(redaction_count=5, consent_granted=True)
 
         assert result is True
         mock_urlopen.assert_called_once()
         body = _decode_post_body(mock_urlopen.call_args)
-        assert body == {FAKE_ENTRY_COUNT: "5", FAKE_ENTRY_TEST_MODE: "true"}
+        assert body == {FAKE_ENTRY_COUNT: "5"}
 
         request = mock_urlopen.call_args.args[0]
         assert request.full_url == FAKE_FORM_URL
         assert request.get_method() == "POST"
-        assert request.get_header("Content-type") == "application/x-www-form-urlencoded"
-
-    @pytest.mark.parametrize(
-        "test_mode, expected",
-        [(True, "true"), (False, "false")],
-    )
-    def test_test_mode_serialised_correctly(self, monkeypatch, test_mode, expected):
-        _set_config(monkeypatch)
-        with patch(
-            "src.persistance.analytics.urllib.request.urlopen",
-            return_value=_make_response(200),
-        ) as mock_urlopen:
-            submit_analytics(
-                redaction_count=0, test_mode=test_mode, consent_granted=True
-            )
-        body = _decode_post_body(mock_urlopen.call_args)
-        assert body[FAKE_ENTRY_TEST_MODE] == expected
+        assert (
+            _get_header_ci(request, "Content-Type")
+            == "application/x-www-form-urlencoded"
+        )
 
     def test_count_coerced_to_str_of_int(self, monkeypatch):
         _set_config(monkeypatch)
@@ -107,7 +95,7 @@ class TestSuccessfulSubmission:
             "src.persistance.analytics.urllib.request.urlopen",
             return_value=_make_response(200),
         ) as mock_urlopen:
-            submit_analytics(redaction_count=42, test_mode=False, consent_granted=True)
+            submit_analytics(redaction_count=42, consent_granted=True)
         body = _decode_post_body(mock_urlopen.call_args)
         assert body[FAKE_ENTRY_COUNT] == "42"
 
@@ -117,24 +105,29 @@ class TestSuccessfulSubmission:
             "src.persistance.analytics.urllib.request.urlopen",
             return_value=_make_response(200),
         ) as mock_urlopen:
-            submit_analytics(
-                redaction_count=1, test_mode=False, consent_granted=True, timeout=2.5
-            )
+            submit_analytics(redaction_count=1, consent_granted=True, timeout=2.5)
         assert mock_urlopen.call_args.kwargs.get("timeout") == 2.5
+
+
+class TestInputValidation:
+    def test_returns_false_on_negative_count(self, monkeypatch):
+        _set_config(monkeypatch)
+        with patch("src.persistance.analytics.urllib.request.urlopen") as mock_urlopen:
+            result = submit_analytics(redaction_count=-1, consent_granted=True)
+        assert result is False
+        mock_urlopen.assert_not_called()
 
 
 class TestMissingConfiguration:
     @pytest.mark.parametrize(
         "blank_attr",
-        ["FORM_URL", "ENTRY_COUNT", "ENTRY_TEST_MODE"],
+        ["FORM_URL", "ENTRY_COUNT"],
     )
     def test_returns_false_when_required_config_blank(self, monkeypatch, blank_attr):
         _set_config(monkeypatch)
         monkeypatch.setattr(analytics_config, blank_attr, "")
         with patch("src.persistance.analytics.urllib.request.urlopen") as mock_urlopen:
-            result = submit_analytics(
-                redaction_count=3, test_mode=False, consent_granted=True
-            )
+            result = submit_analytics(redaction_count=3, consent_granted=True)
         assert result is False
         mock_urlopen.assert_not_called()
 
@@ -146,9 +139,7 @@ class TestErrorHandling:
             "src.persistance.analytics.urllib.request.urlopen",
             side_effect=urllib.error.URLError("boom"),
         ):
-            result = submit_analytics(
-                redaction_count=1, test_mode=True, consent_granted=True
-            )
+            result = submit_analytics(redaction_count=1, consent_granted=True)
         assert result is False
 
     def test_returns_false_on_timeout(self, monkeypatch):
@@ -157,9 +148,7 @@ class TestErrorHandling:
             "src.persistance.analytics.urllib.request.urlopen",
             side_effect=TimeoutError("slow"),
         ):
-            result = submit_analytics(
-                redaction_count=1, test_mode=True, consent_granted=True
-            )
+            result = submit_analytics(redaction_count=1, consent_granted=True)
         assert result is False
 
     def test_returns_false_on_os_error(self, monkeypatch):
@@ -168,9 +157,7 @@ class TestErrorHandling:
             "src.persistance.analytics.urllib.request.urlopen",
             side_effect=OSError("dns"),
         ):
-            result = submit_analytics(
-                redaction_count=1, test_mode=True, consent_granted=True
-            )
+            result = submit_analytics(redaction_count=1, consent_granted=True)
         assert result is False
 
     def test_returns_false_on_non_2xx_status(self, monkeypatch):
@@ -179,7 +166,5 @@ class TestErrorHandling:
             "src.persistance.analytics.urllib.request.urlopen",
             return_value=_make_response(500),
         ):
-            result = submit_analytics(
-                redaction_count=1, test_mode=True, consent_granted=True
-            )
+            result = submit_analytics(redaction_count=1, consent_granted=True)
         assert result is False

--- a/tests/persistance/test_analytics.py
+++ b/tests/persistance/test_analytics.py
@@ -1,0 +1,163 @@
+"""Tests for the analytics submission module."""
+
+from __future__ import annotations
+
+import urllib.error
+import urllib.parse
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.persistance import analytics_config
+from src.persistance.analytics import submit_analytics
+
+FAKE_FORM_URL = "https://docs.google.com/forms/d/e/FAKE/formResponse"
+FAKE_ENTRY_COUNT = "entry.111111111"
+FAKE_ENTRY_TEST_MODE = "entry.222222222"
+
+
+def _set_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(analytics_config, "FORM_URL", FAKE_FORM_URL)
+    monkeypatch.setattr(analytics_config, "ENTRY_COUNT", FAKE_ENTRY_COUNT)
+    monkeypatch.setattr(analytics_config, "ENTRY_TEST_MODE", FAKE_ENTRY_TEST_MODE)
+
+
+def _make_response(status: int) -> MagicMock:
+    """Build a context-manager mock mimicking ``urllib.request.urlopen``'s return."""
+    response = MagicMock()
+    response.status = status
+    response.getcode.return_value = status
+    cm = MagicMock()
+    cm.__enter__.return_value = response
+    cm.__exit__.return_value = False
+    return cm
+
+
+def _decode_post_body(call) -> dict[str, str]:
+    """Extract and decode the urlencoded body from a urlopen call."""
+    request = call.args[0]
+    body = request.data.decode("utf-8")
+    return {k: v[0] for k, v in urllib.parse.parse_qs(body).items()}
+
+
+class TestConsentGate:
+    def test_no_network_call_when_consent_denied(self, monkeypatch):
+        _set_config(monkeypatch)
+        with patch("src.persistance.analytics.urllib.request.urlopen") as mock_urlopen:
+            result = submit_analytics(redaction_count=7, test_mode=False, consent_granted=False)
+        assert result is False
+        mock_urlopen.assert_not_called()
+
+    def test_returns_false_when_consent_denied_even_with_config_blank(self, monkeypatch):
+        monkeypatch.setattr(analytics_config, "FORM_URL", "")
+        monkeypatch.setattr(analytics_config, "ENTRY_COUNT", "")
+        monkeypatch.setattr(analytics_config, "ENTRY_TEST_MODE", "")
+        with patch("src.persistance.analytics.urllib.request.urlopen") as mock_urlopen:
+            result = submit_analytics(redaction_count=1, test_mode=True, consent_granted=False)
+        assert result is False
+        mock_urlopen.assert_not_called()
+
+
+class TestSuccessfulSubmission:
+    def test_posts_count_and_test_mode_and_returns_true(self, monkeypatch):
+        _set_config(monkeypatch)
+        with patch(
+            "src.persistance.analytics.urllib.request.urlopen",
+            return_value=_make_response(200),
+        ) as mock_urlopen:
+            result = submit_analytics(redaction_count=5, test_mode=True, consent_granted=True)
+
+        assert result is True
+        mock_urlopen.assert_called_once()
+        body = _decode_post_body(mock_urlopen.call_args)
+        assert body == {FAKE_ENTRY_COUNT: "5", FAKE_ENTRY_TEST_MODE: "true"}
+
+        request = mock_urlopen.call_args.args[0]
+        assert request.full_url == FAKE_FORM_URL
+        assert request.get_method() == "POST"
+        assert request.get_header("Content-type") == "application/x-www-form-urlencoded"
+
+    @pytest.mark.parametrize(
+        "test_mode, expected",
+        [(True, "true"), (False, "false")],
+    )
+    def test_test_mode_serialised_correctly(self, monkeypatch, test_mode, expected):
+        _set_config(monkeypatch)
+        with patch(
+            "src.persistance.analytics.urllib.request.urlopen",
+            return_value=_make_response(200),
+        ) as mock_urlopen:
+            submit_analytics(redaction_count=0, test_mode=test_mode, consent_granted=True)
+        body = _decode_post_body(mock_urlopen.call_args)
+        assert body[FAKE_ENTRY_TEST_MODE] == expected
+
+    def test_count_coerced_to_str_of_int(self, monkeypatch):
+        _set_config(monkeypatch)
+        with patch(
+            "src.persistance.analytics.urllib.request.urlopen",
+            return_value=_make_response(200),
+        ) as mock_urlopen:
+            submit_analytics(redaction_count=42, test_mode=False, consent_granted=True)
+        body = _decode_post_body(mock_urlopen.call_args)
+        assert body[FAKE_ENTRY_COUNT] == "42"
+
+    def test_timeout_passed_to_urlopen(self, monkeypatch):
+        _set_config(monkeypatch)
+        with patch(
+            "src.persistance.analytics.urllib.request.urlopen",
+            return_value=_make_response(200),
+        ) as mock_urlopen:
+            submit_analytics(redaction_count=1, test_mode=False, consent_granted=True, timeout=2.5)
+        assert mock_urlopen.call_args.kwargs.get("timeout") == 2.5
+
+
+class TestMissingConfiguration:
+    @pytest.mark.parametrize(
+        "blank_attr",
+        ["FORM_URL", "ENTRY_COUNT", "ENTRY_TEST_MODE"],
+    )
+    def test_returns_false_when_required_config_blank(self, monkeypatch, blank_attr):
+        _set_config(monkeypatch)
+        monkeypatch.setattr(analytics_config, blank_attr, "")
+        with patch("src.persistance.analytics.urllib.request.urlopen") as mock_urlopen:
+            result = submit_analytics(redaction_count=3, test_mode=False, consent_granted=True)
+        assert result is False
+        mock_urlopen.assert_not_called()
+
+
+class TestErrorHandling:
+    def test_returns_false_on_url_error(self, monkeypatch):
+        _set_config(monkeypatch)
+        with patch(
+            "src.persistance.analytics.urllib.request.urlopen",
+            side_effect=urllib.error.URLError("boom"),
+        ):
+            result = submit_analytics(redaction_count=1, test_mode=True, consent_granted=True)
+        assert result is False
+
+    def test_returns_false_on_timeout(self, monkeypatch):
+        _set_config(monkeypatch)
+        with patch(
+            "src.persistance.analytics.urllib.request.urlopen",
+            side_effect=TimeoutError("slow"),
+        ):
+            result = submit_analytics(redaction_count=1, test_mode=True, consent_granted=True)
+        assert result is False
+
+    def test_returns_false_on_os_error(self, monkeypatch):
+        _set_config(monkeypatch)
+        with patch(
+            "src.persistance.analytics.urllib.request.urlopen",
+            side_effect=OSError("dns"),
+        ):
+            result = submit_analytics(redaction_count=1, test_mode=True, consent_granted=True)
+        assert result is False
+
+    def test_returns_false_on_non_2xx_status(self, monkeypatch):
+        _set_config(monkeypatch)
+        with patch(
+            "src.persistance.analytics.urllib.request.urlopen",
+            return_value=_make_response(500),
+        ):
+            result = submit_analytics(redaction_count=1, test_mode=True, consent_granted=True)
+        assert result is False


### PR DESCRIPTION
Closes #17.                                                                                                                                        
             
  ## Summary
  - New `src/persistance/analytics.submit_analytics(redaction_count, test_mode, consent_granted, *, timeout=5.0) -> bool` posts the redaction count and
   test-mode flag to a Google Form. Submission carries only those two values — no image content, no identifying info, no timestamp (Google logs that   
  itself).                                                                                                                                             
  - Consent gate is the very first thing in the function: when `consent_granted` is `False`, returns `False` immediately and makes **no** network call,
   no config read, no logging.                                                                                                                         
  - Form URL and entry IDs live in `src/persistance/analytics_config.py` and ship in the binary. Setting any of them to an empty string disables       
  submission cleanly.                                                                                                                           
  - Uses `urllib` from stdlib only — no new dependencies.                                                                                              
                                                                                                                                                     
  ## Test plan                                                                                                                                         
  - [x] `uv run pytest` — 34/34 green, including 17 cases in `tests/persistance/test_analytics.py` covering the consent gate, payload shape (count   
  coerced to `str(int(...))`, `test_mode` serialised as lowercase `"true"`/`"false"`), blank-config disable path, and error handling (`URLError`, 
  `TimeoutError`, `OSError`, non-2xx).                                                                                                                 
  - [x] `uv run black --check src tests` and `uv run isort --check-only src tests` clean.
  - [x] Live smoke test against the real form: granted-consent call returns `True` and writes a row; denied-consent call returns `False` with no       
  network call.                                                                                                                                      
  - [x] Form-side defenses verified by direct `urllib` probe: bogus `test_mode` and missing required fields return HTTP 400; range-out values for      
  `redaction_count` are filtered post-submission by an `onFormSubmit` Apps Script that looks up columns by header name.