### PR TITLE
feat(ui): wire export page to the real ExportOrchestrator

### DIFF
--- a/src/businessLogic/__init__.py
+++ b/src/businessLogic/__init__.py
@@ -5,6 +5,7 @@ from src.businessLogic.export_orchestrator import (
     ExportCommand,
     ExportImageResult,
     ExportOrchestrator,
+    ExportProgress,
     ExportRunResult,
     ExportTask,
 )
@@ -25,6 +26,7 @@ __all__ = [
     "ExportCommand",
     "ExportImageResult",
     "ExportOrchestrator",
+    "ExportProgress",
     "ExportRunResult",
     "ExportTask",
     "ImagePipelineResult",

--- a/src/businessLogic/export_orchestrator.py
+++ b/src/businessLogic/export_orchestrator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
@@ -17,6 +18,7 @@ ImageSaver = Callable[[Image.Image, str | Path, str | None], Path]
 RedactionApplier = Callable[[Image.Image, list[RedactionTarget]], Image.Image]
 AnalyticsSubmitter = Callable[[int, bool], bool]
 ExportResultCallback = Callable[["ExportRunResult"], None]
+ExportProgressCallback = Callable[["ExportProgress"], None]
 
 
 @dataclass(frozen=True, slots=True)
@@ -73,19 +75,37 @@ class ExportRunResult:
     failed_images: int
     results: list[ExportImageResult]
     analytics_submitted: bool = False
+    cancelled: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class ExportProgress:
+    """Progress event emitted after each image in a batch finishes."""
+
+    total_images: int
+    completed_images: int
+    current_image_index: int
+    current_output_path: Path | None
+    success: bool
 
 
 class ExportTask:
     """Handle for a running non-blocking export job."""
 
-    def __init__(self, future: Future) -> None:
+    def __init__(self, future: Future, cancel_event: threading.Event) -> None:
         self._future = future
+        self._cancel_event = cancel_event
 
     @property
     def done(self) -> bool:
         """Return whether the background export job has finished."""
 
         return self._future.done()
+
+    def cancel(self) -> None:
+        """Request that the running export stop before its next image."""
+
+        self._cancel_event.set()
 
 
 class ExportOrchestrator:
@@ -108,42 +128,92 @@ class ExportOrchestrator:
         self,
         commands: list[ExportCommand],
         result_callback: ExportResultCallback | None = None,
+        progress_callback: ExportProgressCallback | None = None,
     ) -> ExportTask:
         """Start export work in one background thread and return immediately."""
 
+        cancel_event = threading.Event()
         future = self._task_executor.submit(
             self._export_and_callback,
             list(commands),
             result_callback,
+            progress_callback,
+            cancel_event,
         )
-        return ExportTask(future)
+        return ExportTask(future, cancel_event)
 
     def export(self, commands: list[ExportCommand]) -> ExportRunResult:
         """Export a batch of images and return per-image status."""
 
-        results: list[ExportImageResult] = []
-        for index, command in enumerate(commands):
-            results.append(self._export_one(index, command))
-
-        successful_images = sum(1 for result in results if result.success)
-        analytics_submitted = self._submit_export_analytics(results)
-        return ExportRunResult(
-            total_images=len(commands),
-            successful_images=successful_images,
-            failed_images=len(commands) - successful_images,
-            results=results,
-            analytics_submitted=analytics_submitted,
+        return self._run_batch(
+            commands,
+            progress_callback=None,
+            cancel_event=threading.Event(),
         )
 
     def _export_and_callback(
         self,
         commands: list[ExportCommand],
         result_callback: ExportResultCallback | None,
+        progress_callback: ExportProgressCallback | None,
+        cancel_event: threading.Event,
     ) -> ExportRunResult:
-        result = self.export(commands)
+        result = self._run_batch(
+            commands,
+            progress_callback=progress_callback,
+            cancel_event=cancel_event,
+        )
         if result_callback is not None:
             result_callback(result)
         return result
+
+    def _run_batch(
+        self,
+        commands: list[ExportCommand],
+        progress_callback: ExportProgressCallback | None,
+        cancel_event: threading.Event,
+    ) -> ExportRunResult:
+        total = len(commands)
+        results: list[ExportImageResult] = []
+        cancelled = False
+
+        for index, command in enumerate(commands):
+            if cancel_event.is_set():
+                cancelled = True
+                results.append(
+                    ExportImageResult(
+                        image_index=index,
+                        success=False,
+                        output_path=_safe_output_path(command.output_path),
+                        redaction_count=len(command.redactions),
+                        error="cancelled",
+                    )
+                )
+            else:
+                results.append(self._export_one(index, command))
+
+            if progress_callback is not None:
+                last = results[-1]
+                progress_callback(
+                    ExportProgress(
+                        total_images=total,
+                        completed_images=index + 1,
+                        current_image_index=index,
+                        current_output_path=last.output_path,
+                        success=last.success,
+                    )
+                )
+
+        successful_images = sum(1 for result in results if result.success)
+        analytics_submitted = self._submit_export_analytics(results)
+        return ExportRunResult(
+            total_images=total,
+            successful_images=successful_images,
+            failed_images=total - successful_images,
+            results=results,
+            analytics_submitted=analytics_submitted,
+            cancelled=cancelled,
+        )
 
     def _export_one(
         self,

--- a/src/persistance/config_manager.py
+++ b/src/persistance/config_manager.py
@@ -50,6 +50,10 @@ class ConfigManager:
 
     @staticmethod
     def get_default_save_directory() -> Path:
-        """Return default directory for
-        saving outputs (user Documents folder)."""
-        return Path.home() / "Documents" / "RedactAI"
+        """Return default directory for saving outputs.
+
+        Uses ``~/Pictures`` rather than ``~/Documents`` so redacted images
+        are not silently swept into iCloud Drive when a user has macOS's
+        "Desktop & Documents Folders" sync enabled.
+        """
+        return Path.home() / "Pictures" / "RedactAI"

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -5,6 +5,7 @@ from enum import Enum
 from PyQt6.QtWidgets import QDialog, QMainWindow, QStackedWidget
 
 from src.ai.object_detector import ObjectDetector
+from src.businessLogic.export_orchestrator import ExportOrchestrator
 from src.businessLogic.pipeline_controller import PipelineController
 from src.persistance.config_manager import ConfigManager
 from src.persistance.resource_loader import ResourceLoader
@@ -45,6 +46,9 @@ class MainWindow(QMainWindow):
         self.pipeline_controller = PipelineController(
             object_detector=ObjectDetector(),
         )
+        self.export_orchestrator = ExportOrchestrator(
+            analytics_consent=self._read_analytics_consent(),
+        )
 
         # Create views
         self.homepage = HomePage(self.go_to)
@@ -53,7 +57,7 @@ class MainWindow(QMainWindow):
         )
         self.placeholder = PlaceholderView(lambda: self.go_to(Page.HOME))
         self.review_page = ReviewPageView(self.go_to)
-        self.export_page = ExportPageView(self.go_to)
+        self.export_page = ExportPageView(self.go_to, self.export_orchestrator)
 
         # Register views in a mapping for unified navigation
         self.views = {
@@ -89,6 +93,13 @@ class MainWindow(QMainWindow):
         config_manager = ConfigManager(config_path)
         config_manager.load()
         return config_manager.get("is_first_launch", True)
+
+    def _read_analytics_consent(self) -> bool:
+        """Return the persisted analytics-consent flag (default: False)."""
+        config_path = ConfigManager.get_default_save_directory() / "config.json"
+        config_manager = ConfigManager(config_path)
+        config_manager.load()
+        return bool(config_manager.get("allow_usage_statistics", False))
 
     def _prompt_analytics_consent(self) -> None:
         """Show the first-run analytics consent dialog once."""

--- a/src/ui/views/export_page.py
+++ b/src/ui/views/export_page.py
@@ -137,7 +137,9 @@ class ExportPageView(QWidget):
 
         commands = _build_export_commands(review_page_output)
         if not commands:
-            self.description.setText("Nothing to export. Returning to the home page.")
+            self.description.setText(
+                "Nothing to export. Click below to return to the home page."
+            )
             self.main_button.setText("Go back to Home")
             self.is_done = True
             return

--- a/src/ui/views/export_page.py
+++ b/src/ui/views/export_page.py
@@ -1,29 +1,61 @@
-"""Export view for showing and executing export functionality."""
+"""Export view that drives the real ExportOrchestrator."""
 
+from __future__ import annotations
+
+from pathlib import Path
 from typing import Callable
 
-from PyQt6.QtCore import Qt, QTimer
-from PyQt6.QtWidgets import QLabel, QPushButton, QVBoxLayout, QWidget
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtWidgets import (
+    QLabel,
+    QProgressBar,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
 
-from src.ui.views.review.types import ReviewPageOutput
+from src.businessLogic.export_orchestrator import (
+    ApprovedRedaction,
+    ExportCommand,
+    ExportOrchestrator,
+    ExportProgress,
+    ExportRunResult,
+    ExportTask,
+)
+from src.persistance.config_manager import ConfigManager
+from src.ui.views.review.types import ApprovedImageRedactions, ReviewPageOutput
 
 
 class ExportPageView(QWidget):
-    """Export view for showing and executing export functionality."""
+    """Export view that runs the real export pipeline asynchronously."""
 
-    def __init__(self, transition_page_fn: Callable) -> None:
+    # Export orchestrator callbacks fire from a worker thread; these signals
+    # marshal the payload back onto the GUI thread before touching widgets.
+    _progress_signal = pyqtSignal(object)
+    _result_signal = pyqtSignal(object)
+
+    def __init__(
+        self,
+        transition_page_fn: Callable,
+        orchestrator: ExportOrchestrator,
+    ) -> None:
         """
         Initialize the export view.
 
         Args:
             transition_page_fn: Function to transition to another page.
+            orchestrator: Shared export orchestrator used to run export jobs.
         """
         super().__init__()
         self.transition_page_fn = transition_page_fn
+        self._orchestrator = orchestrator
         self.launch_extra: dict[str, object] = {}
-        self._setup_ui()
         self.is_done = False
-        self.export_timer: QTimer | None = None  # Timer to simulate export process
+        self._task: ExportTask | None = None
+        self._setup_ui()
+
+        self._progress_signal.connect(self._on_progress)
+        self._result_signal.connect(self._on_complete)
 
     def setLaunchExtra(self, **kwargs: object) -> None:
         """Set extra launch parameters for this page.
@@ -39,54 +71,56 @@ class ExportPageView(QWidget):
         layout.setContentsMargins(40, 40, 40, 40)
         layout.setSpacing(16)
 
-        # Title
         title = QLabel("Exporting step")
         title.setProperty("role", "title")
         title.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
-        # Description
         self.description = QLabel(
             "All redaction targets have been approved. "
             "Click the button below to start exporting."
         )
         self.description.setProperty("role", "subtitle")
         self.description.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.description.setWordWrap(True)
 
-        # Main button
+        self.progress_bar = QProgressBar()
+        self.progress_bar.setMinimum(0)
+        self.progress_bar.setMaximum(100)
+        self.progress_bar.setValue(0)
+        self.progress_bar.setTextVisible(False)
+
+        self.progress_percentage_label = QLabel("0%")
+        self.progress_percentage_label.setProperty("role", "body")
+        self.progress_percentage_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
         self.main_button = QPushButton("Start Export")
         self.main_button.setProperty("role", "primary")
         self.main_button.setMinimumWidth(220)
         self.main_button.clicked.connect(self.main_button_clicked)
 
-        # Add components to layout
         layout.addStretch()
         layout.addWidget(title)
         layout.addWidget(self.description)
+        layout.addWidget(self.progress_bar)
+        layout.addWidget(self.progress_percentage_label)
         layout.addStretch()
         layout.addWidget(self.main_button, 0, Qt.AlignmentFlag.AlignHCenter)
         layout.addStretch()
 
     def main_button_clicked(self) -> None:
+        """Dispatch the button click based on the current state."""
         if self.is_done:
-            # Export already finished, return to home page
-            # import here to avoid circular import
-            from src.ui.main_window import Page
-
-            self.transition_page_fn(Page.HOME)
+            self._go_home()
             return
 
-        # Start export process
-        self.main_button.setEnabled(False)
-        self.main_button.setText("Exporting...")
-        self.description.setText(
-            "Exporting in progress. This may take a few moments..."
-        )
+        if self._task is not None and not self._task.done:
+            self._cancel_export()
+            return
 
         self.start_export_process()
 
     def start_export_process(self) -> None:
-        """Start the export process."""
-
+        """Start the export process by invoking the orchestrator."""
         review_page_output: ReviewPageOutput | None = self.launch_extra.get(
             "output", None
         )
@@ -100,29 +134,128 @@ class ExportPageView(QWidget):
             self.main_button.setEnabled(True)
             self.is_done = True
             return
-        # TODO: start export logic here
-        self.export_timer = QTimer()
-        self.export_timer.setSingleShot(True)
-        self.export_timer.timeout.connect(self.on_export_finished)
-        self.export_timer.start(2000)  # slight delay to allow UI update
 
-    def on_export_finished(self) -> None:
-        """Called when the export process is finished."""
-        self.description.setText(
-            "Export complete! Click the button below to return to the home page."
+        commands = _build_export_commands(review_page_output)
+        if not commands:
+            self.description.setText("Nothing to export. Returning to the home page.")
+            self.main_button.setText("Go back to Home")
+            self.is_done = True
+            return
+
+        self._set_progress(0)
+        self.description.setText(f"Exporting 0 of {len(commands)} images...")
+        self.main_button.setText("Cancel")
+
+        self._task = self._orchestrator.start_export(
+            commands,
+            result_callback=self._result_signal.emit,
+            progress_callback=self._progress_signal.emit,
         )
+
+    def _cancel_export(self) -> None:
+        """Cancel the running export and return to the homepage."""
+        task = self._task
+        if task is None:
+            return
+
+        self.main_button.setEnabled(False)
+        self.description.setText("Cancelling...")
+        task.cancel()
+        # Drop the handle so late progress/result callbacks become no-ops.
+        self._task = None
+        self._go_home()
+
+    def _on_progress(self, event: ExportProgress) -> None:
+        """Handle a progress event marshalled from the export worker."""
+        if self._task is None:
+            return  # cancelled and navigated away — drop late callbacks
+        if event.total_images > 0:
+            pct = int(event.completed_images / event.total_images * 100)
+        else:
+            pct = 0
+        self._set_progress(pct)
+        self.description.setText(
+            f"Exporting image {event.completed_images} of {event.total_images}..."
+        )
+
+    def _on_complete(self, result: ExportRunResult) -> None:
+        """Handle export completion and surface a summary."""
+        if self._task is None or result.cancelled:
+            return  # cancelled job — UI already returned home
+
+        self._set_progress(100)
+        self.description.setText(_summary_text(result))
         self.main_button.setText("Go back to Home")
         self.main_button.setEnabled(True)
         self.is_done = True
-        self.export_timer = None
+        self._task = None
 
     def on_page_become_current(self) -> None:
-        """Called when this page becomes the current page in the stack."""
-
+        """Reset the page to its idle state on activation."""
+        self._task = None
+        self.is_done = False
         self.main_button.setEnabled(True)
         self.main_button.setText("Start Export")
         self.description.setText(
             "All redaction targets have been approved. "
             "Click the button below to start exporting."
         )
-        self.is_done = False
+        self._set_progress(0)
+
+    def _set_progress(self, percent: int) -> None:
+        self.progress_bar.setValue(percent)
+        self.progress_percentage_label.setText(f"{percent}%")
+
+    def _go_home(self) -> None:
+        # Import here to avoid circular dependency.
+        from src.ui.main_window import Page
+
+        self.transition_page_fn(Page.HOME)
+
+
+def _build_export_commands(
+    review_output: ReviewPageOutput,
+) -> list[ExportCommand]:
+    """Convert review-page output into orchestrator export commands."""
+    output_dir = ConfigManager.get_default_save_directory()
+    return [
+        _command_for_image(image, output_dir) for image in review_output.loaded_images
+    ]
+
+
+def _command_for_image(
+    image_record: ApprovedImageRedactions,
+    output_dir: Path,
+) -> ExportCommand:
+    output_path = output_dir / (
+        f"{image_record.path.stem}_redacted{image_record.path.suffix}"
+    )
+    redactions = [
+        ApprovedRedaction(
+            x=target.location.x,
+            y=target.location.y,
+            width=target.location.width,
+            height=target.location.height,
+            mode=target.redaction_type,
+        )
+        for target in image_record.approved_targets
+    ]
+    return ExportCommand(
+        image=image_record.image,
+        output_path=output_path,
+        redactions=redactions,
+    )
+
+
+def _summary_text(result: ExportRunResult) -> str:
+    """Build the post-export description text."""
+    parts = [
+        f"Export complete: {result.successful_images} of "
+        f"{result.total_images} images exported."
+    ]
+    if result.failed_images:
+        parts.append(f"{result.failed_images} failed.")
+    if result.successful_images:
+        output_dir = ConfigManager.get_default_save_directory()
+        parts.append(f"Saved to {output_dir}.")
+    return " ".join(parts)

--- a/tests/businessLogic/test_export_orchestrator.py
+++ b/tests/businessLogic/test_export_orchestrator.py
@@ -13,6 +13,7 @@ from src.businessLogic.export_orchestrator import (
     ApprovedRedaction,
     ExportCommand,
     ExportOrchestrator,
+    ExportProgress,
 )
 from src.redactEngine import RedactionType
 
@@ -207,3 +208,82 @@ def test_export_passes_approved_coordinates_to_redaction_engine(tmp_path) -> Non
     assert captured_targets[0].location.width == 6
     assert captured_targets[0].location.height == 7
     assert captured_targets[0].redaction_type == RedactionType.PIXELATE
+
+
+def test_start_export_invokes_progress_callback_per_image(tmp_path) -> None:
+    events: list[ExportProgress] = []
+
+    image = Image.new("RGB", (20, 20), color=(255, 255, 255))
+    orchestrator = ExportOrchestrator()
+    commands = [
+        ExportCommand(
+            image=image,
+            output_path=tmp_path / f"out_{index}.png",
+            redactions=[],
+        )
+        for index in range(3)
+    ]
+
+    task = orchestrator.start_export(commands, progress_callback=events.append)
+    for _ in range(50):
+        if task.done:
+            break
+        time.sleep(0.05)
+
+    assert task.done is True
+    assert [event.completed_images for event in events] == [1, 2, 3]
+    assert all(event.total_images == 3 for event in events)
+    assert all(event.success for event in events)
+
+
+def test_cancel_stops_subsequent_exports_and_marks_remaining_failed(tmp_path) -> None:
+    proceed_after_first = threading.Event()
+    seen_indices: list[int] = []
+
+    def blocking_saver(image, output_path, image_format):
+        index = len(seen_indices)
+        seen_indices.append(index)
+        if index == 0:
+            proceed_after_first.wait(timeout=2.0)
+        return Path(output_path)
+
+    image = Image.new("RGB", (20, 20), color=(255, 255, 255))
+    orchestrator = ExportOrchestrator(image_saver=blocking_saver)
+    commands = [
+        ExportCommand(
+            image=image,
+            output_path=tmp_path / f"out_{index}.png",
+            redactions=[],
+        )
+        for index in range(3)
+    ]
+
+    callback_results = []
+    task = orchestrator.start_export(
+        commands,
+        result_callback=callback_results.append,
+    )
+
+    # Wait until the first image is in-flight, then cancel.
+    for _ in range(50):
+        if seen_indices:
+            break
+        time.sleep(0.02)
+    task.cancel()
+    proceed_after_first.set()
+
+    for _ in range(50):
+        if callback_results:
+            break
+        time.sleep(0.05)
+
+    assert task.done is True
+    result = callback_results[0]
+    assert result.cancelled is True
+    assert result.results[0].success is True
+    assert result.results[1].success is False
+    assert result.results[1].error == "cancelled"
+    assert result.results[2].success is False
+    assert result.results[2].error == "cancelled"
+    assert result.successful_images == 1
+    assert result.failed_images == 2

--- a/tests/persistance/test_config_manager.py
+++ b/tests/persistance/test_config_manager.py
@@ -21,5 +21,5 @@ def test_default_save_directory():
 
     save_dir = cm.get_default_save_directory()
 
-    assert "Documents" in str(save_dir)
+    assert "Pictures" in str(save_dir)
     assert "RedactAI" in str(save_dir)

--- a/tests/ui/views/test_export_page.py
+++ b/tests/ui/views/test_export_page.py
@@ -23,7 +23,10 @@ from src.ui.views.review.types import ApprovedImageRedactions, ReviewPageOutput
 
 @pytest.fixture(scope="module")
 def qt_app():
-    app = QApplication.instance() or QApplication([])
+    # "-platform offscreen" lets the fixture work in headless CI (no X server)
+    # without requiring xvfb. setdefault avoids overriding if another fixture
+    # already constructed a QApplication.
+    app = QApplication.instance() or QApplication(["", "-platform", "offscreen"])
     yield app
 
 

--- a/tests/ui/views/test_export_page.py
+++ b/tests/ui/views/test_export_page.py
@@ -1,0 +1,211 @@
+"""Tests for ExportPageView's orchestrator integration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from PIL import Image
+from PyQt6.QtWidgets import QApplication
+
+from src.ai.types import BoundingBox
+from src.businessLogic.export_orchestrator import (
+    ExportCommand,
+    ExportImageResult,
+    ExportProgress,
+    ExportRunResult,
+)
+from src.persistance.config_manager import ConfigManager
+from src.redactEngine.redactor import RedactionTarget, RedactionType
+from src.ui.views.export_page import ExportPageView, _build_export_commands
+from src.ui.views.review.types import ApprovedImageRedactions, ReviewPageOutput
+
+
+@pytest.fixture(scope="module")
+def qt_app():
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+def _image() -> Image.Image:
+    return Image.new("RGB", (20, 20), color=(255, 255, 255))
+
+
+def _approved(path: Path, *targets: RedactionTarget) -> ApprovedImageRedactions:
+    return ApprovedImageRedactions(
+        path=path,
+        image=_image(),
+        approved_targets=list(targets),
+    )
+
+
+def _target(x: int, y: int, w: int, h: int, mode: RedactionType) -> RedactionTarget:
+    return RedactionTarget(
+        location=BoundingBox(x=x, y=y, width=w, height=h),
+        redaction_type=mode,
+    )
+
+
+class _FakeOrchestrator:
+    """Records commands and exposes callbacks for the test to flush manually.
+
+    Real callbacks fire from a worker thread *after* start_export returns and
+    the page stores the task handle. Firing them synchronously here would race
+    that assignment and the page would treat them as late no-ops.
+    """
+
+    def __init__(self, run_result: ExportRunResult) -> None:
+        self._run_result = run_result
+        self.commands: list[ExportCommand] = []
+        self.cancelled = False
+        self._result_callback = None
+        self._progress_callback = None
+
+    def start_export(
+        self,
+        commands,
+        result_callback=None,
+        progress_callback=None,
+    ):
+        self.commands = list(commands)
+        self._result_callback = result_callback
+        self._progress_callback = progress_callback
+        return _StubTask(self)
+
+    def flush(self) -> None:
+        if self._progress_callback is not None:
+            total = len(self.commands)
+            for index, command in enumerate(self.commands):
+                self._progress_callback(
+                    ExportProgress(
+                        total_images=total,
+                        completed_images=index + 1,
+                        current_image_index=index,
+                        current_output_path=Path(command.output_path),
+                        success=True,
+                    )
+                )
+        if self._result_callback is not None:
+            self._result_callback(self._run_result)
+
+
+class _StubTask:
+    def __init__(self, orchestrator: _FakeOrchestrator) -> None:
+        self._orchestrator = orchestrator
+        self.done = True
+
+    def cancel(self) -> None:
+        self._orchestrator.cancelled = True
+
+
+def test_build_export_commands_uses_default_save_directory_with_suffix() -> None:
+    review_output = ReviewPageOutput(
+        failed_paths=[],
+        loaded_images=[
+            _approved(Path("/inbox/photo.jpg")),
+            _approved(Path("/inbox/scan.PNG")),
+        ],
+    )
+
+    commands = _build_export_commands(review_output)
+
+    save_dir = ConfigManager.get_default_save_directory()
+    assert [c.output_path for c in commands] == [
+        save_dir / "photo_redacted.jpg",
+        save_dir / "scan_redacted.PNG",
+    ]
+
+
+def test_build_export_commands_converts_redaction_targets() -> None:
+    target = _target(4, 5, 6, 7, RedactionType.PIXELATE)
+    review_output = ReviewPageOutput(
+        failed_paths=[],
+        loaded_images=[_approved(Path("/inbox/a.png"), target)],
+    )
+
+    commands = _build_export_commands(review_output)
+
+    assert len(commands) == 1
+    [redaction] = commands[0].redactions
+    assert (redaction.x, redaction.y) == (4, 5)
+    assert (redaction.width, redaction.height) == (6, 7)
+    assert redaction.mode == RedactionType.PIXELATE
+
+
+def test_export_page_invokes_orchestrator_and_summarizes_result(qt_app) -> None:
+    run_result = ExportRunResult(
+        total_images=2,
+        successful_images=2,
+        failed_images=0,
+        results=[
+            ExportImageResult(image_index=0, success=True, redaction_count=1),
+            ExportImageResult(image_index=1, success=True, redaction_count=0),
+        ],
+    )
+    orchestrator = _FakeOrchestrator(run_result)
+
+    def transition(*_args, **_kwargs):
+        return None
+
+    page = ExportPageView(transition, orchestrator)  # type: ignore[arg-type]
+    page.setLaunchExtra(
+        output=ReviewPageOutput(
+            failed_paths=[],
+            loaded_images=[
+                _approved(
+                    Path("/inbox/a.png"), _target(1, 2, 3, 4, RedactionType.BLACK_BAR)
+                ),
+                _approved(Path("/inbox/b.png")),
+            ],
+        )
+    )
+
+    page.start_export_process()
+    orchestrator.flush()
+    qt_app.processEvents()
+
+    assert len(orchestrator.commands) == 2
+    save_dir = ConfigManager.get_default_save_directory()
+    assert orchestrator.commands[0].output_path == save_dir / "a_redacted.png"
+    assert orchestrator.commands[1].output_path == save_dir / "b_redacted.png"
+
+    text = page.description.text()
+    assert "2 of 2" in text
+    assert page.main_button.text() == "Go back to Home"
+    assert page.is_done is True
+
+
+def test_export_page_cancel_invokes_orchestrator_and_drops_task(qt_app) -> None:
+    transitions: list[object] = []
+
+    def transition(page, **_kwargs):
+        transitions.append(page)
+
+    run_result = ExportRunResult(
+        total_images=1,
+        successful_images=0,
+        failed_images=1,
+        results=[],
+        cancelled=True,
+    )
+    orchestrator = _FakeOrchestrator(run_result)
+    page = ExportPageView(transition, orchestrator)  # type: ignore[arg-type]
+    page.setLaunchExtra(
+        output=ReviewPageOutput(
+            failed_paths=[],
+            loaded_images=[_approved(Path("/inbox/a.png"))],
+        )
+    )
+
+    page.start_export_process()
+    qt_app.processEvents()
+    # Pretend the export is still running so cancel takes the cancel branch.
+    in_flight = _StubTask(orchestrator)
+    in_flight.done = False
+    page._task = in_flight
+
+    page._cancel_export()
+
+    assert orchestrator.cancelled is True
+    assert transitions  # navigated home
+    assert page._task is None


### PR DESCRIPTION
## Summary
- Replace QTimer mock in `ExportPageView` with real start/cancel/finish flow against `ExportOrchestrator` (mirrors the detection-progress `pyqtSignal` pattern; adds a `QProgressBar` and per-image status text)
- Extend orchestrator with `threading.Event` cancel on `ExportTask` and per-image `ExportProgress` callback; final description summarizes `successful_images` / `failed_images` from `ExportRunResult`
- `MainWindow` owns and injects a shared `ExportOrchestrator`
- Move default save dir from `~/Documents/RedactAI` to `~/Pictures/RedactAI` so redacted images aren't swept into iCloud Drive when "Desktop & Documents Folders" sync is on

Closes #44.

## Test plan
- [x] `uv run pytest tests/businessLogic/test_export_orchestrator.py tests/ui/views/test_export_page.py tests/persistance/test_config_manager.py` — 14/14 passed
- [x] `uv run black --check src tests && uv run isort --check-only src tests && uv run flake8 src tests` — clean
- [x] Drop 3+ real images, run detection → review → export; confirm progress bar advances and files land in `~/Pictures/RedactAI/<name>_redacted.<ext>`
- [x] Cancel mid-batch: confirm UI returns home and only the partially-exported files exist on disk
- [x] One-image-fails case (e.g. make the save dir unwritable): confirm summary reads "N exported, M failed" without crashing